### PR TITLE
Add setup API placeholder and query variant tags

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ export default function App() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [currentStep, setCurrentStep] = useState<AppStep>(AppStep.SETUP);
   const [model, setModel] = useState<string>('gemini-2.5-pro');
+  const [threshold, setThreshold] = useState<number>(0.05);
   
   const [projectDetails, setProjectDetails] = useState<ProjectDetails>({
     title: '',
@@ -71,7 +72,7 @@ export default function App() {
   const renderStep = () => {
     switch (currentStep) {
       case AppStep.SETUP:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} />;
+        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} threshold={threshold} setThreshold={setThreshold} />;
       case AppStep.PROJECT_DEFINITION:
         return <ProjectPage 
             projectDetails={projectDetails} 
@@ -85,7 +86,7 @@ export default function App() {
             searchLog={searchLog}
         />;
       case AppStep.SCREENING:
-        return <ScreeningPage papers={papers} setPapers={setPapers} projectDetails={projectDetails} onComplete={() => setCurrentStep(AppStep.SUMMARY_GENERATION)} onBack={handleBack} model={model} />;
+        return <ScreeningPage papers={papers} setPapers={setPapers} projectDetails={projectDetails} onComplete={() => setCurrentStep(AppStep.SUMMARY_GENERATION)} onBack={handleBack} model={model} threshold={threshold} />;
       case AppStep.SUMMARY_GENERATION:
         return <SummaryPage papers={keptPapers} summaries={summaries} setSummaries={setSummaries} onComplete={() => setCurrentStep(AppStep.DRAFTING)} onBack={handleBack} model={model} />;
       case AppStep.DRAFTING:
@@ -93,7 +94,7 @@ export default function App() {
       case AppStep.EXPORT:
         return <ExportPage papers={papers} searchLog={searchLog} draft={draft} projectTitle={projectDetails.title} onBack={handleBack} model={model} duplicateCount={duplicateCount} />;
       default:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} />;
+        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} threshold={threshold} setThreshold={setThreshold} />;
     }
   };
 
@@ -102,7 +103,7 @@ export default function App() {
       <header className="bg-white dark:bg-primary-900/50 backdrop-blur-sm border-b border-slate-200 dark:border-primary-700 sticky top-0 z-30">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            <h1 className="text-xl font-bold text-primary-700 dark:text-primary-400">AutoReview</h1>
+            <h1 className="text-xl font-bold text-primary-700 dark:text-primary-400">Systematic Review Automator</h1>
             <button
               onClick={toggleTheme}
               className="p-2 rounded-full hover:bg-slate-200 dark:hover:bg-primary-800 text-slate-500 dark:text-primary-400"

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AutoReview</title>
+    <title>Systematic Review Automator</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "AutoReview",
+  "name": "Systematic Review Automator",
   "description": "A client-side application to automate the systematic review process using the Gemini API, from searching for papers to drafting the final review.",
   "requestFramePermissions": [],
   "prompt": ""

--- a/pages/ProjectPage.tsx
+++ b/pages/ProjectPage.tsx
@@ -22,9 +22,21 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
   const [loadingMessage, setLoadingMessage] = useState('');
   const [strategyDeveloped, setStrategyDeveloped] = useState(false);
   const [recommendedDatabases, setRecommendedDatabases] = useState<string[]>([]);
+  const [newVariant, setNewVariant] = useState('');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setProjectDetails(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleAddVariant = () => {
+    const v = newVariant.trim();
+    if (!v) return;
+    setProjectDetails(prev => ({ ...prev, queryVariants: [...prev.queryVariants, v] }));
+    setNewVariant('');
+  };
+
+  const handleRemoveVariant = (variant: string) => {
+    setProjectDetails(prev => ({ ...prev, queryVariants: prev.queryVariants.filter(v => v !== variant) }));
   };
 
   const handleDevelopStrategy = async () => {
@@ -110,6 +122,32 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
             <label htmlFor="searchTerms" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Boolean Term Suggestions</label>
             <textarea name="searchTerms" id="searchTerms" rows={4} value={projectDetails.searchTerms} onChange={handleChange} disabled={strategyDeveloped} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 font-mono text-sm disabled:bg-slate-100 dark:disabled:bg-primary-800/50" placeholder='e.g. ("myocardial infarction" OR "heart attack") AND (prevention OR therapy)'></textarea>
             {strategyDeveloped && <p className="mt-1 text-xs text-slate-500 dark:text-primary-400">Query has been finalized by the AI. To change it, you must go back and restart this step.</p>}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-primary-300">Query Variants & Synonyms</label>
+            <div className="mt-1 flex gap-2">
+              <input
+                type="text"
+                value={newVariant}
+                onChange={e => setNewVariant(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddVariant(); } }}
+                className="flex-grow rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm"
+                placeholder="Add variant"
+              />
+              <button type="button" onClick={handleAddVariant} className="px-3 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-md text-sm">Add</button>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {projectDetails.queryVariants.map(v => (
+                <span key={v} className="inline-flex items-center px-2 py-1 rounded-full bg-primary-100 dark:bg-primary-800 text-primary-800 dark:text-primary-200 text-xs">
+                  {v}
+                  <button type="button" onClick={() => handleRemoveVariant(v)} className="ml-1 text-primary-600 hover:text-primary-800 dark:text-primary-400">&times;</button>
+                </span>
+              ))}
+              {projectDetails.queryVariants.length === 0 && (
+                <span className="text-slate-400 dark:text-primary-500 text-sm italic">No variants added.</span>
+              )}
+            </div>
           </div>
 
           {strategyDeveloped && (

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -11,13 +11,14 @@ interface ScreeningPageProps {
   onComplete: () => void;
   onBack: () => void;
   model: string;
+  threshold: number;
 }
 
 type ScreeningStage = 'title' | 'abstract' | 'full-text';
 
 const STAGES: ScreeningStage[] = ['title', 'abstract', 'full-text'];
 
-const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projectDetails, onComplete, onBack, model }) => {
+const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projectDetails, onComplete, onBack, model, threshold }) => {
   const [currentStage, setCurrentStage] = useState<ScreeningStage>('title');
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -48,7 +49,7 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
       const paper = papersToClassify[i];
       const contentToClassify = stage === 'title' ? paper.title : (paper.abstract || paper.title);
       // NOTE: A real full-text review would fetch content, here we just use the abstract again as a proxy.
-      const classification = await classifyPaperPart(stage, contentToClassify, projectDetails, model);
+      const classification = await classifyPaperPart(stage, contentToClassify, projectDetails, model, threshold);
       
       const paperIndex = updatedPapers.findIndex(p => p.id === paper.id);
       if (paperIndex !== -1) {

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -68,8 +68,7 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     }
     
     setIsLoading(false);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectDetails, model, papers.length]);
+  }, [papers, projectDetails, model, threshold]);
 
   useEffect(() => {
       // Find the first paper that needs classification in the current stage to avoid re-running on every paper update

--- a/pages/SetupPage.tsx
+++ b/pages/SetupPage.tsx
@@ -5,22 +5,40 @@ interface SetupPageProps {
   onComplete: () => void;
   model: string;
   setModel: (model: string) => void;
+  threshold: number;
+  setThreshold: (value: number) => void;
 }
 
-const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel }) => {
+const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel, threshold, setThreshold }) => {
   const availableModels = ['gemini-2.5-pro', 'gemini-2.5-flash'];
+  const apiKeyPlaceholder = 'process.env.GEMINI_API_KEY';
 
   return (
     <div className="max-w-2xl mx-auto">
       <div className="text-center">
         <SparklesIcon className="mx-auto h-12 w-12 text-primary-500" />
-        <h2 className="mt-2 text-3xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-4xl">AutoReview</h2>
+        <h2 className="mt-2 text-3xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-4xl">Systematic Review Automator</h2>
         <p className="mt-4 text-lg text-slate-600 dark:text-primary-300">
           Select your model to Automate the creation of a Systematic Review defined by you.
         </p>
       </div>
       <div className="mt-10 bg-white dark:bg-primary-900 p-8 rounded-lg shadow-lg border border-slate-200 dark:border-primary-700">
         <div className="space-y-6">
+          <div>
+            <label htmlFor="api-key" className="block text-sm font-medium text-slate-700 dark:text-primary-300">
+              Gemini API Key
+            </label>
+            <input
+              id="api-key"
+              type="text"
+              readOnly
+              value={apiKeyPlaceholder}
+              className="mt-1 block w-full rounded-md border-slate-300 bg-slate-100 text-slate-900 dark:bg-primary-800 dark:text-primary-100 dark:border-primary-700 shadow-sm"
+            />
+            <p className="mt-2 text-xs text-slate-500 dark:text-primary-400">
+              This placeholder value is used for all API calls client-side.
+            </p>
+          </div>
           <div>
             <label htmlFor="ai-model" className="block text-sm font-medium text-slate-700 dark:text-primary-300">
               AI Model
@@ -39,6 +57,24 @@ const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel }) =>
                 Select the AI model to power your review.
               </p>
             </div>
+          </div>
+          <div>
+            <label htmlFor="threshold" className="block text-sm font-medium text-slate-700 dark:text-primary-300">
+              Keep Threshold
+            </label>
+            <input
+              id="threshold"
+              type="number"
+              step="0.01"
+              min="0"
+              max="1"
+              value={threshold}
+              onChange={(e) => setThreshold(parseFloat(e.target.value))}
+              className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm"
+            />
+            <p className="mt-2 text-xs text-slate-500 dark:text-primary-400">
+              Higher values make the AI stricter when keeping papers.
+            </p>
           </div>
           <div className="pt-4">
             <button

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,14 +1,40 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { ProjectDetails, Paper, Summary, DraftSection, CitationStyle, ExclusionReason } from '../types';
 
-if (!process.env.API_KEY) {
+if (!process.env.GEMINI_API_KEY) {
   // In a real app, you'd want to handle this more gracefully.
   // For this sandboxed environment, we assume it's available.
-  console.warn("API_KEY environment variable not set. Using a placeholder.");
-  process.env.API_KEY = "YOUR_API_KEY_HERE";
+  console.warn("GEMINI_API_KEY environment variable not set. Using a placeholder.");
+  process.env.GEMINI_API_KEY = "YOUR_API_KEY_HERE";
 }
 
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+const EMBEDDING_MODEL = 'text-embedding-004';
+
+const cleanText = (text: string) =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const embedText = async (text: string): Promise<number[]> => {
+  const resp = await ai.models.embedContent({ model: EMBEDDING_MODEL, contents: [text] });
+  return resp.embeddings?.[0]?.values || [];
+};
+
+const dot = (a: number[], b: number[]) => a.reduce((sum, v, i) => sum + v * (b[i] || 0), 0);
+const magnitude = (a: number[]) => Math.sqrt(a.reduce((sum, v) => sum + v * v, 0));
+const cosineSim = (a: number[], b: number[]) => {
+  const denom = magnitude(a) * magnitude(b);
+  return denom === 0 ? 0 : dot(a, b) / denom;
+};
+
+const labelEmbeddingsPromise = Promise.all([
+  embedText('keep'),
+  embedText('exclude')
+]);
 
 const classificationSchema = {
     type: Type.OBJECT,
@@ -57,31 +83,28 @@ const strategySchema = {
 };
 
 
-export const classifyPaperPart = async (part: 'title' | 'abstract' | 'full-text', content: string, projectDetails: ProjectDetails, modelName: string) => {
-    const prompt = `
-        A systematic review is being conducted with the title "${projectDetails.title}".
-        The goal is: "${projectDetails.description}".
-        
-        Based on this goal, analyze the following paper's ${part}:
-        ---
-        ${content}
-        ---
-        Should this paper be included or excluded? Provide a confidence score and a brief justification.
-    `;
-
+export const classifyPaperPart = async (
+    part: 'title' | 'abstract' | 'full-text',
+    content: string,
+    _projectDetails: ProjectDetails,
+    _modelName: string,
+    threshold: number
+) => {
     try {
-        const response = await ai.models.generateContent({
-            model: modelName,
-            contents: prompt,
-            config: {
-                responseMimeType: "application/json",
-                responseSchema: classificationSchema,
-            }
-        });
-        const jsonText = response.text.trim();
-        return JSON.parse(jsonText);
+        const [keepEmb, excludeEmb] = await labelEmbeddingsPromise;
+        const textEmb = await embedText(cleanText(content));
+
+        const keepSim = cosineSim(textEmb, keepEmb);
+        const excludeSim = cosineSim(textEmb, excludeEmb);
+        const score = keepSim - excludeSim;
+
+        return {
+            decision: score >= threshold ? 'keep' as const : 'exclude' as const,
+            confidence: Math.round(Math.abs(score) * 100),
+            justification: `similarity keep ${keepSim.toFixed(2)} exclude ${excludeSim.toFixed(2)}`
+        };
     } catch (error) {
-        console.error(`Error classifying paper ${part}:`, error);
+        console.error(`Error classifying paper ${part} via embeddings:`, error);
         return { decision: 'exclude', confidence: 0, justification: 'Error during analysis.' };
     }
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- rename app to **Systematic Review Automator**
- show placeholder API key on the setup screen
- allow adding/removing query variant tags on the project page
- update Gemini service to use `process.env.GEMINI_API_KEY`
- classify papers using embeddings with a configurable keep threshold

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68835a41d800832492876dae387ce49c