### PR TITLE
Add testing mode and extra sources

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ export default function App() {
     description: '',
     searchTerms: '',
     queryVariants: [],
+    analysisFocus: '',
     useUnpaywall: true,
     useOpenAlt: true,
     searchProfiles: [],
@@ -131,7 +132,7 @@ export default function App() {
       case AppStep.SCREENING:
         return <ScreeningPage papers={papers} setPapers={setPapers} projectDetails={projectDetails} onComplete={() => setCurrentStep(AppStep.SUMMARY_GENERATION)} onBack={handleBack} model={model} />;
       case AppStep.SUMMARY_GENERATION:
-        return <SummaryPage papers={keptPapers} summaries={summaries} setSummaries={setSummaries} onComplete={() => setCurrentStep(AppStep.DRAFTING)} onBack={handleBack} model={model} />;
+        return <SummaryPage papers={keptPapers} summaries={summaries} setSummaries={setSummaries} onComplete={() => setCurrentStep(AppStep.DRAFTING)} onBack={handleBack} model={model} analysisFocus={projectDetails.analysisFocus || ''} />;
       case AppStep.DRAFTING:
         return <DraftingPage summaries={summaries} draft={draft} setDraft={setDraft} onComplete={() => setCurrentStep(AppStep.EXPORT)} onBack={handleBack} projectDetails={projectDetails} model={model} />;
       case AppStep.EXPORT:

--- a/App.tsx
+++ b/App.tsx
@@ -41,18 +41,25 @@ export default function App() {
     [DraftSection.ABSTRACT]: '',
   });
 
-  // restore snapshot
+  const [hasSnapshot, setHasSnapshot] = useState(false);
+
+  // detect saved snapshot but don't auto restore
   useEffect(() => {
-    const snap = localStorage.getItem('snapshot');
-    if (snap) {
-      try {
-        const data = JSON.parse(snap);
-        setProjectDetails(data.projectDetails || projectDetails);
-        setPapers(data.papers || []);
-        setCurrentStep(data.currentStep || AppStep.SETUP);
-      } catch {}
+    if (localStorage.getItem('snapshot')) {
+      setHasSnapshot(true);
     }
   }, []);
+
+  const restoreSnapshot = () => {
+    const snap = localStorage.getItem('snapshot');
+    if (!snap) return;
+    try {
+      const data = JSON.parse(snap);
+      setProjectDetails(data.projectDetails || projectDetails);
+      setPapers(data.papers || []);
+      setCurrentStep(data.currentStep || AppStep.SETUP);
+    } catch {}
+  };
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -99,7 +106,15 @@ export default function App() {
   const renderStep = () => {
     switch (currentStep) {
       case AppStep.SETUP:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} />;
+        return <SetupPage
+          onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)}
+          onResume={restoreSnapshot}
+          hasSnapshot={hasSnapshot}
+          model={model}
+          setModel={setModel}
+          testing={testing}
+          setTesting={setTesting}
+        />;
       case AppStep.PROJECT_DEFINITION:
         return <ProjectPage
             projectDetails={projectDetails}
@@ -122,7 +137,15 @@ export default function App() {
       case AppStep.EXPORT:
         return <ExportPage papers={papers} searchLog={searchLog} draft={draft} projectTitle={projectDetails.title} onBack={handleBack} model={model} duplicateCount={duplicateCount} />;
       default:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} />;
+        return <SetupPage
+          onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)}
+          onResume={restoreSnapshot}
+          hasSnapshot={hasSnapshot}
+          model={model}
+          setModel={setModel}
+          testing={testing}
+          setTesting={setTesting}
+        />;
     }
   };
 

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { AppStep, Paper, ProjectDetails, ScreeningDecision, Summary, DraftSection, SearchLogEntry } from './types';
 import SetupPage from './pages/SetupPage';
 import ProjectPage from './pages/ProjectPage';
@@ -13,13 +13,27 @@ export default function App() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [currentStep, setCurrentStep] = useState<AppStep>(AppStep.SETUP);
   const [model, setModel] = useState<string>('gemini-2.5-pro');
+  const [testing, setTesting] = useState<boolean>(false);
   
   const [projectDetails, setProjectDetails] = useState<ProjectDetails>({
     title: '',
     description: '',
     searchTerms: '',
     queryVariants: [],
+    useUnpaywall: true,
+    useOpenAlt: false,
+    searchProfiles: [],
+    activeProfileId: undefined,
+    sourceFilters: {},
   });
+
+  const setUseUnpaywall = (val: boolean) => {
+    setProjectDetails(prev => ({ ...prev, useUnpaywall: val }));
+  };
+
+  const setUseOpenAlt = (val: boolean) => {
+    setProjectDetails(prev => ({ ...prev, useOpenAlt: val }));
+  };
 
   const [papers, setPapers] = useState<Paper[]>([]);
   const [searchLog, setSearchLog] = useState<SearchLogEntry[]>([]);
@@ -33,6 +47,27 @@ export default function App() {
     [DraftSection.DISCUSSION]: '',
     [DraftSection.ABSTRACT]: '',
   });
+
+  // restore snapshot
+  useEffect(() => {
+    const snap = localStorage.getItem('snapshot');
+    if (snap) {
+      try {
+        const data = JSON.parse(snap);
+        setProjectDetails(data.projectDetails || projectDetails);
+        setPapers(data.papers || []);
+        setCurrentStep(data.currentStep || AppStep.SETUP);
+      } catch {}
+    }
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const snap = { projectDetails, papers, currentStep };
+      localStorage.setItem('snapshot', JSON.stringify(snap));
+    }, 60000);
+    return () => clearInterval(id);
+  }, [projectDetails, papers, currentStep]);
 
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
@@ -71,18 +106,19 @@ export default function App() {
   const renderStep = () => {
     switch (currentStep) {
       case AppStep.SETUP:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} />;
+        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} useUnpaywall={projectDetails.useUnpaywall ?? true} setUseUnpaywall={setUseUnpaywall} useOpenAlt={projectDetails.useOpenAlt ?? false} setUseOpenAlt={setUseOpenAlt} projectDetails={projectDetails} setProjectDetails={setProjectDetails} />;
       case AppStep.PROJECT_DEFINITION:
-        return <ProjectPage 
-            projectDetails={projectDetails} 
-            setProjectDetails={setProjectDetails} 
-            setPapers={setPapers} 
-            setSearchLog={setSearchLog} 
+        return <ProjectPage
+            projectDetails={projectDetails}
+            setProjectDetails={setProjectDetails}
+            setPapers={setPapers}
+            setSearchLog={setSearchLog}
             setDuplicateCount={setDuplicateCount}
-            onStartSearch={() => setCurrentStep(AppStep.SCREENING)} 
-            onBack={handleBack} 
+            onStartSearch={() => setCurrentStep(AppStep.SCREENING)}
+            onBack={handleBack}
             model={model}
             searchLog={searchLog}
+            testing={testing}
         />;
       case AppStep.SCREENING:
         return <ScreeningPage papers={papers} setPapers={setPapers} projectDetails={projectDetails} onComplete={() => setCurrentStep(AppStep.SUMMARY_GENERATION)} onBack={handleBack} model={model} />;
@@ -93,7 +129,7 @@ export default function App() {
       case AppStep.EXPORT:
         return <ExportPage papers={papers} searchLog={searchLog} draft={draft} projectTitle={projectDetails.title} onBack={handleBack} model={model} duplicateCount={duplicateCount} />;
       default:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} />;
+        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} useUnpaywall={projectDetails.useUnpaywall ?? true} setUseUnpaywall={setUseUnpaywall} useOpenAlt={projectDetails.useOpenAlt ?? false} setUseOpenAlt={setUseOpenAlt} projectDetails={projectDetails} setProjectDetails={setProjectDetails} />;
     }
   };
 

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { AppStep, Paper, ProjectDetails, ScreeningDecision, Summary, DraftSection, SearchLogEntry } from './types';
+import { AppStep, Paper, ProjectDetails, ScreeningDecision, Summary, SearchLogEntry, DefaultDraftSections } from './types';
 import SetupPage from './pages/SetupPage';
 import ProjectPage from './pages/ProjectPage';
 import ScreeningPage from './pages/ScreeningPage';
@@ -14,6 +14,8 @@ export default function App() {
   const [currentStep, setCurrentStep] = useState<AppStep>(AppStep.SETUP);
   const [model, setModel] = useState<string>('gemini-2.5-pro');
   const [testing, setTesting] = useState<boolean>(false);
+
+  const [tokenCount, setTokenCount] = useState<number>(0);
   
   const [projectDetails, setProjectDetails] = useState<ProjectDetails>({
     title: '',
@@ -35,13 +37,9 @@ export default function App() {
   const [duplicateCount, setDuplicateCount] = useState(0);
 
   const [summaries, setSummaries] = useState<Summary[]>([]);
-  const [draft, setDraft] = useState<Record<DraftSection, string>>({
-    [DraftSection.INTRODUCTION]: '',
-    [DraftSection.METHODS]: '',
-    [DraftSection.RESULTS]: '',
-    [DraftSection.DISCUSSION]: '',
-    [DraftSection.ABSTRACT]: '',
-  });
+  const initDraft: Record<string, string> = {};
+  DefaultDraftSections.forEach(sec => { initDraft[sec] = ''; });
+  const [draft, setDraft] = useState<Record<string, string>>(initDraft);
 
   const [hasSnapshot, setHasSnapshot] = useState(false);
 
@@ -70,6 +68,37 @@ export default function App() {
     }, 60000);
     return () => clearInterval(id);
   }, [projectDetails, papers, currentStep]);
+
+  // update draft structure when reportStructure changes
+  useEffect(() => {
+    const sections = (projectDetails.reportStructure || DefaultDraftSections.join('\n'))
+      .split('\n')
+      .map(s => s.trim())
+      .filter(Boolean);
+    setDraft(prev => {
+      const updated: Record<string, string> = {};
+      sections.forEach(sec => {
+        updated[sec] = prev[sec] || '';
+      });
+      return updated;
+    });
+  }, [projectDetails.reportStructure]);
+
+  // update token count whenever Gemini logs are written
+  useEffect(() => {
+    const update = () => {
+      try {
+        const logs = JSON.parse(localStorage.getItem('gemini_logs') || '[]');
+        const total = logs.reduce((a: number, b: any) => a + (b.tokens || 0), 0);
+        setTokenCount(total);
+      } catch {
+        setTokenCount(0);
+      }
+    };
+    update();
+    window.addEventListener('geminiLog', update);
+    return () => window.removeEventListener('geminiLog', update);
+  }, []);
 
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
@@ -137,7 +166,7 @@ export default function App() {
       case AppStep.DRAFTING:
         return <DraftingPage summaries={summaries} draft={draft} setDraft={setDraft} onComplete={() => setCurrentStep(AppStep.EXPORT)} onBack={handleBack} projectDetails={projectDetails} model={model} />;
       case AppStep.EXPORT:
-        return <ExportPage papers={papers} searchLog={searchLog} draft={draft} projectTitle={projectDetails.title} onBack={handleBack} model={model} duplicateCount={duplicateCount} />;
+        return <ExportPage papers={papers} searchLog={searchLog} draft={draft} projectTitle={projectDetails.title} reportStructure={projectDetails.reportStructure || ''} onBack={handleBack} model={model} duplicateCount={duplicateCount} />;
       default:
         return <SetupPage
           onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)}
@@ -157,13 +186,16 @@ export default function App() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <h1 className="text-xl font-bold text-primary-700 dark:text-primary-400">AutoReview</h1>
-            <button
+            <div className="flex items-center gap-4">
+              <span className="text-sm text-slate-600 dark:text-primary-300">Tokens: {tokenCount}</span>
+              <button
               onClick={toggleTheme}
               className="p-2 rounded-full hover:bg-slate-200 dark:hover:bg-primary-800 text-slate-500 dark:text-primary-400"
               aria-label="Toggle theme"
             >
               {theme === 'light' ? <MoonIcon className="w-6 h-6" /> : <SunIcon className="w-6 h-6" />}
-            </button>
+              </button>
+            </div>
           </div>
         </div>
       </header>

--- a/App.tsx
+++ b/App.tsx
@@ -20,7 +20,8 @@ export default function App() {
     description: '',
     searchTerms: '',
     queryVariants: [],
-    analysisFocus: '',
+    analysisPlan: 'Summarise study quality, outcomes, and key comparisons to inform clinical decision making.',
+    reportStructure: 'Introduction\nMethods\nResults\nDiscussion\nConclusion',
     useUnpaywall: true,
     useOpenAlt: true,
     searchProfiles: [],
@@ -132,7 +133,7 @@ export default function App() {
       case AppStep.SCREENING:
         return <ScreeningPage papers={papers} setPapers={setPapers} projectDetails={projectDetails} onComplete={() => setCurrentStep(AppStep.SUMMARY_GENERATION)} onBack={handleBack} model={model} />;
       case AppStep.SUMMARY_GENERATION:
-        return <SummaryPage papers={keptPapers} summaries={summaries} setSummaries={setSummaries} onComplete={() => setCurrentStep(AppStep.DRAFTING)} onBack={handleBack} model={model} analysisFocus={projectDetails.analysisFocus || ''} />;
+        return <SummaryPage papers={keptPapers} summaries={summaries} setSummaries={setSummaries} onComplete={() => setCurrentStep(AppStep.DRAFTING)} onBack={handleBack} model={model} analysisPlan={projectDetails.analysisPlan || ''} />;
       case AppStep.DRAFTING:
         return <DraftingPage summaries={summaries} draft={draft} setDraft={setDraft} onComplete={() => setCurrentStep(AppStep.EXPORT)} onBack={handleBack} projectDetails={projectDetails} model={model} />;
       case AppStep.EXPORT:

--- a/App.tsx
+++ b/App.tsx
@@ -21,19 +21,12 @@ export default function App() {
     searchTerms: '',
     queryVariants: [],
     useUnpaywall: true,
-    useOpenAlt: false,
+    useOpenAlt: true,
     searchProfiles: [],
     activeProfileId: undefined,
     sourceFilters: {},
   });
 
-  const setUseUnpaywall = (val: boolean) => {
-    setProjectDetails(prev => ({ ...prev, useUnpaywall: val }));
-  };
-
-  const setUseOpenAlt = (val: boolean) => {
-    setProjectDetails(prev => ({ ...prev, useOpenAlt: val }));
-  };
 
   const [papers, setPapers] = useState<Paper[]>([]);
   const [searchLog, setSearchLog] = useState<SearchLogEntry[]>([]);
@@ -106,7 +99,7 @@ export default function App() {
   const renderStep = () => {
     switch (currentStep) {
       case AppStep.SETUP:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} useUnpaywall={projectDetails.useUnpaywall ?? true} setUseUnpaywall={setUseUnpaywall} useOpenAlt={projectDetails.useOpenAlt ?? false} setUseOpenAlt={setUseOpenAlt} projectDetails={projectDetails} setProjectDetails={setProjectDetails} />;
+        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} />;
       case AppStep.PROJECT_DEFINITION:
         return <ProjectPage
             projectDetails={projectDetails}
@@ -129,7 +122,7 @@ export default function App() {
       case AppStep.EXPORT:
         return <ExportPage papers={papers} searchLog={searchLog} draft={draft} projectTitle={projectDetails.title} onBack={handleBack} model={model} duplicateCount={duplicateCount} />;
       default:
-        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} useUnpaywall={projectDetails.useUnpaywall ?? true} setUseUnpaywall={setUseUnpaywall} useOpenAlt={projectDetails.useOpenAlt ?? false} setUseOpenAlt={setUseOpenAlt} projectDetails={projectDetails} setProjectDetails={setProjectDetails} />;
+        return <SetupPage onComplete={() => setCurrentStep(AppStep.PROJECT_DEFINITION)} model={model} setModel={setModel} testing={testing} setTesting={setTesting} />;
     }
   };
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This contains everything you need to run your app locally.
 - The AI suggests relevant databases (PubMed, Crossref, OpenAlex, ERIC, BASE, NASA ADS, DataCite, WHO GIM/LILACS, DBLP, etc.). You can adjust this list before running the search.
 - "Testing mode" limits results to 10 per source after deduplication (hover for details).
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
-- The app periodically saves a snapshot locally so crashes can be recovered.
+- The app periodically saves a snapshot locally so crashes can be recovered. A
+  **Resume Previous Session** button will appear on the welcome page if data is
+  available.
 - Use `VITE_USE_WORKERS=true npm run dev` in development to enable workers.
 - If workers fail to start, the app will automatically process AI screening on the main thread.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This contains everything you need to run your app locally.
 - "Testing mode" limits results to 10 per source after deduplication (hover for details).
 - A running total of Gemini tokens is shown on the export page diagnostics.
 - Boolean search terms are generated automatically from your description.
+- Downloads include a single PDF report or a ZIP containing that PDF and any
+  available full-text articles.
 - Use the "Analysis" and "Report Structure" fields to guide what the summaries and draft should cover.
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
 - The app periodically saves a snapshot locally so crashes can be recovered. A

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This contains everything you need to run your app locally.
 - The AI suggests relevant databases (PubMed, Crossref, OpenAlex, ERIC, BASE, NASA ADS, DataCite, WHO GIM/LILACS, DBLP, etc.). You can adjust this list before running the search.
 - "Testing mode" limits results to 10 per source after deduplication (hover for details).
 - A running total of Gemini tokens is shown on the export page diagnostics.
-- Use the "Analysis Focus" field to specify topics or indications you want emphasised in summaries and drafts.
+- Boolean search terms are generated automatically from your description.
+- Use the "Analysis" and "Report Structure" fields to guide what the summaries and draft should cover.
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
 - The app periodically saves a snapshot locally so crashes can be recovered. A
   **Resume Previous Session** button will appear on the welcome page if data is

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This contains everything you need to run your app locally.
 - "Testing mode" limits results to 10 per source after deduplication (hover for details).
 - A running total of Gemini tokens is shown on the export page diagnostics.
 - Boolean search terms are generated automatically from your description.
-- Downloads include a single PDF report or a ZIP containing that PDF and any
-  available full-text articles.
+- Downloads include a **Report PDF** or a **ZIP** that bundles the PDF with all
+  available full-text article PDFs.
 - Use the "Analysis" and "Report Structure" fields to guide what the summaries and draft should cover.
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
 - The app periodically saves a snapshot locally so crashes can be recovered. A

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This contains everything you need to run your app locally.
 
 - The AI suggests relevant databases (PubMed, Crossref, OpenAlex, ERIC, BASE, NASA ADS, DataCite, WHO GIM/LILACS, DBLP, etc.). You can adjust this list before running the search.
 - "Testing mode" limits results to 10 per source after deduplication (hover for details).
+- A running total of Gemini tokens is shown on the export page diagnostics.
+- Use the "Analysis Focus" field to specify topics or indications you want emphasised in summaries and drafts.
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
 - The app periodically saves a snapshot locally so crashes can be recovered. A
   **Resume Previous Session** button will appear on the welcome page if data is

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Notes
+
+- Additional Boolean-searchable sources like ERIC, BASE, NASA ADS, DataCite, WHO GIM/LILACS and DBLP are available. Enable them in the first step and set year/language filters.
+- "Testing mode" limits results to 10 per source after deduplication (hover for details).
+- Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
+- The app periodically saves a snapshot locally so crashes can be recovered.
+- Use `VITE_USE_WORKERS=true npm run dev` in development to enable workers.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ This contains everything you need to run your app locally.
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
 - The app periodically saves a snapshot locally so crashes can be recovered.
 - Use `VITE_USE_WORKERS=true npm run dev` in development to enable workers.
+- If workers fail to start, the app will automatically process AI screening on the main thread.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This contains everything you need to run your app locally.
 
 ## Notes
 
-- Additional Boolean-searchable sources like ERIC, BASE, NASA ADS, DataCite, WHO GIM/LILACS and DBLP are available. Enable them in the first step and set year/language filters.
+- The AI suggests relevant databases (PubMed, Crossref, OpenAlex, ERIC, BASE, NASA ADS, DataCite, WHO GIM/LILACS, DBLP, etc.). You can adjust this list before running the search.
 - "Testing mode" limits results to 10 per source after deduplication (hover for details).
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
 - The app periodically saves a snapshot locally so crashes can be recovered.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This contains everything you need to run your app locally.
 - A running total of Gemini tokens is shown on the export page diagnostics.
 - Boolean search terms are generated automatically from your description.
 - Downloads include a **Report PDF** or a **ZIP** that bundles the PDF with all
-  available full-text article PDFs.
+  available full-text article PDFs. The ZIP now reliably includes any fetched
+  full-text PDFs alongside the report.
 - Use the "Analysis" and "Report Structure" fields to guide what the summaries and draft should cover.
 - Keyboard shortcuts during screening: **K** to keep, **E** to exclude, **Enter** to advance.
 - The app periodically saves a snapshot locally so crashes can be recovered. A

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+class ErrorBoundary extends React.Component<React.PropsWithChildren<{}>, ErrorBoundaryState> {
+  constructor(props: React.PropsWithChildren<{}>) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('Unhandled error:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 m-4 border rounded bg-red-50 text-red-800">
+          <h2 className="font-bold">Something went wrong.</h2>
+          <p className="text-sm break-all">{this.state.error?.message}</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { useState } from 'react';
 import { Paper } from '../types';
 import { XMarkIcon } from './Icons';
 
@@ -9,6 +9,10 @@ interface ModalProps {
 }
 
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, paper }) => {
+    const [draft, setDraft] = useState<Paper | null>(paper);
+    React.useEffect(() => {
+        setDraft(paper);
+    }, [paper]);
     if (!isOpen || !paper) return null;
 
     return (
@@ -21,11 +25,10 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, paper }) => {
                         <div className="bg-white dark:bg-primary-900 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                             <div className="sm:flex sm:items-start">
                                 <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
-                                    <h3 className="text-lg font-semibold leading-6 text-slate-900 dark:text-primary-100" id="modal-title">
-                                        {paper.title}
-                                    </h3>
-                                    <div className="mt-2">
-                                        <p className="text-sm text-slate-600 dark:text-primary-400">{paper.authors.join(", ")} ({paper.year}) - <em>{paper.source}</em></p>
+                                    <div className="space-y-2">
+                                        <input className="w-full border rounded p-1" value={draft?.title || ''} onChange={e => setDraft(d => d ? { ...d, title: e.target.value } : d)} />
+                                        <input className="w-full border rounded p-1" value={draft?.year || ''} onChange={e => setDraft(d => d ? { ...d, year: parseInt(e.target.value) || 0 } : d)} />
+                                        <input className="w-full border rounded p-1" value={draft?.id || ''} onChange={e => setDraft(d => d ? { ...d, id: e.target.value } : d)} />
                                     </div>
                                     <div className="mt-4 prose dark:prose-invert max-w-none">
                                         {paper.oaPdfUrl && (
@@ -41,7 +44,8 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, paper }) => {
                                 </div>
                             </div>
                         </div>
-                        <div className="bg-slate-50 dark:bg-primary-900/50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                        <div className="bg-slate-50 dark:bg-primary-900/50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 gap-2">
+                            <button type="button" className="inline-flex justify-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary-700 sm:w-auto" onClick={() => { if(draft) Object.assign(paper, draft); onClose(); }}>Save</button>
                             <button
                                 type="button"
                                 className="mt-3 inline-flex w-full justify-center rounded-md bg-white dark:bg-primary-800 px-3 py-2 text-sm font-semibold text-slate-900 dark:text-primary-200 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-primary-700 hover:bg-slate-50 dark:hover:bg-primary-700 sm:mt-0 sm:w-auto"

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -21,7 +21,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, paper }) => {
 
             <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
                 <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-                    <div className="relative transform overflow-hidden rounded-lg bg-white dark:bg-primary-900 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-3xl">
+                    <div className="relative transform overflow-hidden rounded-lg bg-white dark:bg-primary-900 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-3xl max-h-[90vh] overflow-y-auto flex flex-col">
                         <div className="bg-white dark:bg-primary-900 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                             <div className="sm:flex sm:items-start">
                                 <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">

--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -10,6 +11,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1572 @@
+{
+  "name": "autoreview",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "autoreview",
+      "version": "0.0.0",
+      "dependencies": {
+        "@google/genai": "^1.11.0",
+        "chart.js": "^4.4.0",
+        "jszip": "^3.10.1",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-window": "^1.8.8"
+      },
+      "devDependencies": {
+        "@types/node": "^22.14.0",
+        "typescript": "~5.7.2",
+        "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
+      "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.11.0.tgz",
+      "integrity": "sha512-4XFAHCvU91ewdWOU3RUdSeXpDuZRJHNYLqT9LKw7WqPjRQcEJvVU+VOU49ocruaSp8VuLKMecl0iadlQK+Zgfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
+      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
+      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
+      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
+      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
+      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
+      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
+      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
+      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
+      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
+      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
+      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
+      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
+      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
+      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
+      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
+      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
+      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
+      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
+      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
+      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.16.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
+      "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
+      "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.8",
+        "@esbuild/android-arm": "0.25.8",
+        "@esbuild/android-arm64": "0.25.8",
+        "@esbuild/android-x64": "0.25.8",
+        "@esbuild/darwin-arm64": "0.25.8",
+        "@esbuild/darwin-x64": "0.25.8",
+        "@esbuild/freebsd-arm64": "0.25.8",
+        "@esbuild/freebsd-x64": "0.25.8",
+        "@esbuild/linux-arm": "0.25.8",
+        "@esbuild/linux-arm64": "0.25.8",
+        "@esbuild/linux-ia32": "0.25.8",
+        "@esbuild/linux-loong64": "0.25.8",
+        "@esbuild/linux-mips64el": "0.25.8",
+        "@esbuild/linux-ppc64": "0.25.8",
+        "@esbuild/linux-riscv64": "0.25.8",
+        "@esbuild/linux-s390x": "0.25.8",
+        "@esbuild/linux-x64": "0.25.8",
+        "@esbuild/netbsd-arm64": "0.25.8",
+        "@esbuild/netbsd-x64": "0.25.8",
+        "@esbuild/openbsd-arm64": "0.25.8",
+        "@esbuild/openbsd-x64": "0.25.8",
+        "@esbuild/openharmony-arm64": "0.25.8",
+        "@esbuild/sunos-x64": "0.25.8",
+        "@esbuild/win32-arm64": "0.25.8",
+        "@esbuild/win32-ia32": "0.25.8",
+        "@esbuild/win32-x64": "0.25.8"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
+      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.45.1",
+        "@rollup/rollup-android-arm64": "4.45.1",
+        "@rollup/rollup-darwin-arm64": "4.45.1",
+        "@rollup/rollup-darwin-x64": "4.45.1",
+        "@rollup/rollup-freebsd-arm64": "4.45.1",
+        "@rollup/rollup-freebsd-x64": "4.45.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
+        "@rollup/rollup-linux-arm64-musl": "4.45.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
+        "@rollup/rollup-linux-x64-gnu": "4.45.1",
+        "@rollup/rollup-linux-x64-musl": "4.45.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
+        "@rollup/rollup-win32-x64-msvc": "4.45.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.11.0",
         "chart.js": "^4.4.0",
+        "jspdf": "^2.5.1",
         "jszip": "^3.10.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -796,6 +797,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -803,6 +811,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -834,11 +864,43 @@
         "node": "*"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chart.js": {
       "version": "4.5.0",
@@ -852,11 +914,33 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -874,6 +958,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -946,6 +1037,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1031,6 +1128,20 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -1081,6 +1192,24 @@
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jszip": {
@@ -1182,6 +1311,13 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1236,6 +1372,16 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -1295,6 +1441,23 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -1378,6 +1541,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1392,6 +1565,26 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -1442,6 +1635,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@google/genai": "^1.11.0",
     "react-window": "^1.8.8",
     "chart.js": "^4.4.0",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@google/genai": "^1.11.0"
+    "@google/genai": "^1.11.0",
+    "react-window": "^1.8.8",
+    "chart.js": "^4.4.0",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/pages/DraftingPage.tsx
+++ b/pages/DraftingPage.tsx
@@ -1,36 +1,39 @@
-import React, { useState } from 'react';
-import { Summary, DraftSection, ProjectDetails } from '../types';
+import React, { useState, useMemo, useEffect } from 'react';
+import { Summary, ProjectDetails, DefaultDraftSections } from '../types';
 import { generateDraftSection } from '../services/geminiService';
 import { SparklesIcon } from '../components/Icons';
 
 interface DraftingPageProps {
   summaries: Summary[];
-  draft: Record<DraftSection, string>;
-  setDraft: React.Dispatch<React.SetStateAction<Record<DraftSection, string>>>;
+  draft: Record<string, string>;
+  setDraft: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   onComplete: () => void;
   onBack: () => void;
   projectDetails: ProjectDetails;
   model: string;
 }
 
-const TABS: DraftSection[] = [
-    DraftSection.INTRODUCTION,
-    DraftSection.METHODS,
-    DraftSection.RESULTS,
-    DraftSection.DISCUSSION,
-    DraftSection.ABSTRACT,
-];
-
 const DraftingPage: React.FC<DraftingPageProps> = ({ summaries, draft, setDraft, onComplete, onBack, projectDetails, model }) => {
-  const [activeTab, setActiveTab] = useState<DraftSection>(DraftSection.INTRODUCTION);
-  const [loadingSection, setLoadingSection] = useState<DraftSection | null>(null);
+  const sections = useMemo(() => {
+    const lines = (projectDetails.reportStructure || DefaultDraftSections.join('\n'))
+      .split('\n')
+      .map(s => s.trim())
+      .filter(Boolean);
+    return lines.length > 0 ? lines : [...DefaultDraftSections];
+  }, [projectDetails.reportStructure]);
 
-  const handleRegenerate = async (section: DraftSection) => {
+  const [activeTab, setActiveTab] = useState<string>(sections[0]);
+  useEffect(() => {
+    setActiveTab(sections[0]);
+  }, [sections]);
+  const [loadingSection, setLoadingSection] = useState<string | null>(null);
+
+  const handleRegenerate = async (section: string) => {
     setLoadingSection(section);
     let content: string | Summary[];
-    if (section === DraftSection.INTRODUCTION) {
+    if (section.toLowerCase() === 'introduction') {
         content = projectDetails.title;
-    } else if (section === DraftSection.ABSTRACT) {
+    } else if (section.toLowerCase() === 'abstract') {
         // Combine other sections for the abstract context
         content = `Introduction: ${draft.Introduction}\nMethods: ${draft.Methods}\nResults: ${draft.Results}\nDiscussion: ${draft.Discussion}`;
     }
@@ -48,7 +51,7 @@ const DraftingPage: React.FC<DraftingPageProps> = ({ summaries, draft, setDraft,
     }
   };
 
-  const handleTextChange = (section: DraftSection, text: string) => {
+  const handleTextChange = (section: string, text: string) => {
     setDraft(prev => ({...prev, [section]: text}));
   };
 
@@ -65,7 +68,7 @@ const DraftingPage: React.FC<DraftingPageProps> = ({ summaries, draft, setDraft,
       <div className="my-6">
         <div className="border-b border-gray-200 dark:border-primary-700">
             <nav className="-mb-px flex space-x-8" aria-label="Tabs">
-              {TABS.map((tab) => (
+              {sections.map((tab) => (
                 <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}

--- a/pages/DraftingPage.tsx
+++ b/pages/DraftingPage.tsx
@@ -39,7 +39,7 @@ const DraftingPage: React.FC<DraftingPageProps> = ({ summaries, draft, setDraft,
     }
 
     try {
-      const newContent = await generateDraftSection(section, content, model);
+      const newContent = await generateDraftSection(section, content, model, projectDetails.analysisFocus);
       setDraft(prev => ({...prev, [section]: newContent}));
     } catch (error) {
         console.error(`Failed to generate ${section}`, error);

--- a/pages/DraftingPage.tsx
+++ b/pages/DraftingPage.tsx
@@ -39,7 +39,7 @@ const DraftingPage: React.FC<DraftingPageProps> = ({ summaries, draft, setDraft,
     }
 
     try {
-      const newContent = await generateDraftSection(section, content, model, projectDetails.analysisFocus);
+      const newContent = await generateDraftSection(section, content, model, projectDetails.analysisPlan);
       setDraft(prev => ({...prev, [section]: newContent}));
     } catch (error) {
         console.error(`Failed to generate ${section}`, error);

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -1,8 +1,12 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { Chart, BarController, BarElement, CategoryScale, LinearScale } from 'chart.js';
+import JSZip from 'jszip';
 import { Paper, DraftSection, CitationStyle, SearchLogEntry, PrismaCounts, ScreeningDecision } from '../types';
 import { generateCitations } from '../services/geminiService';
 import { calculatePrismaCounts } from '../utils/prismaUtils';
 import PrismaDiagram from '../components/PrismaDiagram';
+
+Chart.register(BarController, BarElement, CategoryScale, LinearScale);
 
 interface ExportPageProps {
   papers: Paper[];
@@ -18,10 +22,37 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
   const [citationStyle, setCitationStyle] = useState<CitationStyle>(CitationStyle.APA);
   const [citations, setCitations] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
+  const [autoExport, setAutoExport] = useState(false);
+
+  const diagnostics = useMemo(() => {
+    const keys = Object.keys(localStorage).filter(k => k.startsWith('timing_'));
+    return keys.map(k => {
+      const arr = JSON.parse(localStorage.getItem(k) || '[]');
+      const avg = arr.reduce((a:number,b:number)=>a+b,0) / (arr.length || 1);
+      return { db: k.replace('timing_',''), avg };
+    });
+  }, []);
 
   const prismaCounts: PrismaCounts = useMemo(() => {
     return calculatePrismaCounts(papers, searchLog, duplicateCount);
   }, [papers, searchLog, duplicateCount]);
+
+  const chartRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+    const ctx = chartRef.current.getContext('2d');
+    if (!ctx) return;
+    const data = papers.filter(p => p.fullTextDecision === ScreeningDecision.KEEP).reduce((acc:any,p) => {
+      acc[p.dbSource] = (acc[p.dbSource] || 0) + 1;
+      return acc;
+    }, {} as Record<string,number>);
+    new Chart(ctx, {
+      type: 'bar',
+      data: { labels: Object.keys(data), datasets: [{ label: 'Included', data: Object.values(data), backgroundColor: '#3b82f6' }] },
+      options: { responsive: false }
+    });
+  }, [papers]);
 
   const fullText = `
 # ${projectTitle}
@@ -74,6 +105,34 @@ ${citations}
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
   };
+
+  const downloadAsRIS = () => {
+    const lines = papers.filter(p => p.fullTextDecision === ScreeningDecision.KEEP).map(p => `TY  - JOUR\nTI  - ${p.title}\nAU  - ${p.authors.join('; ')}\nPY  - ${p.year}\nUR  - ${p.fullTextUrl}\nER  -`);
+    const blob = new Blob([lines.join('\n')], { type: 'application/x-research-info-systems' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${projectTitle.replace(/\s+/g, '_')}.ris`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadZip = async () => {
+    const zip = new JSZip();
+    zip.file('review.txt', fullText);
+    zip.file('citations.ris', papers.map(p => p.title).join('\n'));
+    const content = await zip.generateAsync({ type: 'blob' });
+    const url = URL.createObjectURL(content);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${projectTitle.replace(/\s+/g, '_')}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
   
   const downloadSearchLog = () => {
     const header = "Database,Query,Hits,Date\n";
@@ -91,6 +150,13 @@ ${citations}
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
   }
+
+  useEffect(() => {
+    if (autoExport && citations) {
+      downloadAsTxt();
+      downloadSearchLog();
+    }
+  }, [autoExport, citations]);
 
   return (
     <div className="space-y-8">
@@ -110,6 +176,7 @@ ${citations}
           </div>
           <div className="mt-6 p-4 flex justify-center bg-slate-50 dark:bg-black rounded-lg">
             <PrismaDiagram counts={prismaCounts} />
+            <canvas id="sourceChart" className="ml-8" width="300" height="200" ref={chartRef}></canvas>
           </div>
       </div>
       
@@ -170,10 +237,15 @@ ${citations}
             <textarea readOnly value={citations} rows={10} className="mt-1 block w-full rounded-md border-slate-300 bg-slate-50 dark:bg-primary-950 dark:border-primary-700 shadow-sm sm:text-sm" placeholder="Generated citations will appear here..."/>
             <div>
               <h3 className="text-lg font-semibold">Download</h3>
-              <p className="text-sm text-slate-500 dark:text-primary-400 mt-1">Download the complete review as a text file.</p>
+              <p className="text-sm text-slate-500 dark:text-primary-400 mt-1">Download the complete review.</p>
               <button onClick={downloadAsTxt} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
                   Download .txt
               </button>
+              <button onClick={downloadAsRIS} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">Download .ris</button>
+              <button onClick={downloadZip} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">Download ZIP</button>
+              <label className="mt-2 flex items-center text-sm">
+                <input type="checkbox" className="mr-2" checked={autoExport} onChange={e => setAutoExport(e.target.checked)} /> Auto-export on finish
+              </label>
             </div>
           </div>
           <div className="md:col-span-2">
@@ -183,6 +255,16 @@ ${citations}
               </div>
           </div>
         </div>
+        {diagnostics.length > 0 && (
+          <div className="mt-8">
+            <h3 className="text-lg font-semibold">Diagnostics</h3>
+            <ul className="mt-2 text-sm list-disc pl-6">
+              {diagnostics.map(d => (
+                <li key={d.db}>{d.db}: avg {d.avg.toFixed(0)} ms</li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -26,11 +26,15 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
 
   const diagnostics = useMemo(() => {
     const keys = Object.keys(localStorage).filter(k => k.startsWith('timing_'));
-    return keys.map(k => {
+    const dbStats = keys.map(k => {
       const arr = JSON.parse(localStorage.getItem(k) || '[]');
       const avg = arr.reduce((a:number,b:number)=>a+b,0) / (arr.length || 1);
       return { db: k.replace('timing_',''), avg };
     });
+    const aiLogs = JSON.parse(localStorage.getItem('gemini_logs') || '[]');
+    const aiCount = aiLogs.length;
+    const aiAvg = aiLogs.reduce((a:any,b:any)=>a+(b.ms||0),0) / (aiCount || 1);
+    return [...dbStats, { db: 'Gemini calls', avg: aiAvg, count: aiCount }];
   }, []);
 
   const prismaCounts: PrismaCounts = useMemo(() => {
@@ -260,7 +264,7 @@ ${citations}
             <h3 className="text-lg font-semibold">Diagnostics</h3>
             <ul className="mt-2 text-sm list-disc pl-6">
               {diagnostics.map(d => (
-                <li key={d.db}>{d.db}: avg {d.avg.toFixed(0)} ms</li>
+                <li key={d.db}>{d.db}: avg {d.avg.toFixed(0)} ms{d.count !== undefined ? ` (${d.count} calls)` : ''}</li>
               ))}
             </ul>
           </div>

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -34,7 +34,8 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
     const aiLogs = JSON.parse(localStorage.getItem('gemini_logs') || '[]');
     const aiCount = aiLogs.length;
     const aiAvg = aiLogs.reduce((a:any,b:any)=>a+(b.ms||0),0) / (aiCount || 1);
-    return [...dbStats, { db: 'Gemini calls', avg: aiAvg, count: aiCount }];
+    const tokenTotal = aiLogs.reduce((a:any,b:any)=>a+(b.tokens||0),0);
+    return [...dbStats, { db: 'Gemini calls', avg: aiAvg, count: aiCount, tokens: tokenTotal }];
   }, []);
 
   const prismaCounts: PrismaCounts = useMemo(() => {
@@ -264,7 +265,7 @@ ${citations}
             <h3 className="text-lg font-semibold">Diagnostics</h3>
             <ul className="mt-2 text-sm list-disc pl-6">
               {diagnostics.map(d => (
-                <li key={d.db}>{d.db}: avg {d.avg.toFixed(0)} ms{d.count !== undefined ? ` (${d.count} calls)` : ''}</li>
+                <li key={d.db}>{d.db}: avg {d.avg.toFixed(0)} ms{d.count !== undefined ? ` (${d.count} calls)` : ''}{d.tokens !== undefined ? `, ${d.tokens} tokens` : ''}</li>
               ))}
             </ul>
           </div>

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -158,17 +158,19 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
     const included = papers.filter(p => p.fullTextDecision === ScreeningDecision.KEEP);
     for (const p of included) {
       const url = p.oaPdfUrl || p.fullTextUrl;
-      if (url && url.endsWith('.pdf')) {
-        try {
-          const resp = await fetch(url);
-          if (resp.ok) {
-            const blob = await resp.blob();
+      if (!url) continue;
+      try {
+        const resp = await fetch(url);
+        if (resp.ok) {
+          const blob = await resp.blob();
+          const contentType = resp.headers.get('Content-Type') || '';
+          if (contentType.includes('pdf') || url.toLowerCase().includes('.pdf')) {
             const safeTitle = p.title.replace(/[^a-z0-9]/gi, '_').slice(0, 30);
             zip.file(`${safeTitle}.pdf`, blob);
           }
-        } catch (err) {
-          console.warn('Failed to fetch PDF', err);
         }
+      } catch (err) {
+        console.warn('Failed to fetch PDF', err);
       }
     }
 

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { Chart, BarController, BarElement, CategoryScale, LinearScale } from 'chart.js';
 import JSZip from 'jszip';
-import { Paper, DraftSection, CitationStyle, SearchLogEntry, PrismaCounts, ScreeningDecision } from '../types';
+import { Paper, CitationStyle, SearchLogEntry, PrismaCounts, ScreeningDecision, DefaultDraftSections } from '../types';
 import { generateCitations } from '../services/geminiService';
 import { calculatePrismaCounts } from '../utils/prismaUtils';
 import PrismaDiagram from '../components/PrismaDiagram';
@@ -11,14 +11,15 @@ Chart.register(BarController, BarElement, CategoryScale, LinearScale);
 interface ExportPageProps {
   papers: Paper[];
   searchLog: SearchLogEntry[];
-  draft: Record<DraftSection, string>;
+  draft: Record<string, string>;
   projectTitle: string;
+  reportStructure: string;
   onBack: () => void;
   model: string;
   duplicateCount: number;
 }
 
-const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, projectTitle, onBack, model, duplicateCount }) => {
+const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, projectTitle, reportStructure, onBack, model, duplicateCount }) => {
   const [citationStyle, setCitationStyle] = useState<CitationStyle>(CitationStyle.APA);
   const [citations, setCitations] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
@@ -59,27 +60,22 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
     });
   }, [papers]);
 
-  const fullText = `
-# ${projectTitle}
+  const sections = useMemo(() => {
+    const lines = (reportStructure || DefaultDraftSections.join('\n'))
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean);
+    return lines.length > 0 ? lines : [...DefaultDraftSections];
+  }, [reportStructure]);
 
-## Abstract
-${draft.Abstract}
-
-## Introduction
-${draft.Introduction}
-
-## Methods
-${draft.Methods}
-
-## Results
-${draft.Results}
-
-## Discussion
-${draft.Discussion}
-
-## References
-${citations}
-  `.trim();
+  const fullText = useMemo(() => {
+    const parts = [`# ${projectTitle}`];
+    sections.forEach(sec => {
+      parts.push(`## ${sec}`, draft[sec] || '');
+    });
+    parts.push('## References', citations);
+    return parts.join('\n\n').trim();
+  }, [projectTitle, sections, draft, citations]);
 
   const handleGenerateCitations = useCallback(async () => {
     const papersToCite = papers.filter(p => p.fullTextDecision === ScreeningDecision.KEEP);

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -102,33 +102,52 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
     }
   }, [papers, citationStyle, model]);
   
-  const downloadAsPDF = () => {
+  const createPdfDoc = () => {
     const doc = new jsPDF();
-    const lines = fullText.split('\n');
-    let y = 10;
-    lines.forEach(line => {
-      const parts = doc.splitTextToSize(line, 180);
-      parts.forEach(t => {
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(20);
+    doc.text(projectTitle, 10, 20);
+    doc.setFontSize(12);
+    doc.setFont('helvetica', 'normal');
+    let y = 30;
+    sections.forEach(sec => {
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(16);
+      if (y > 280) { doc.addPage(); y = 20; }
+      doc.text(sec, 10, y);
+      y += 8;
+      doc.setFontSize(12);
+      doc.setFont('helvetica', 'normal');
+      const lines = doc.splitTextToSize(draft[sec] || '', 180);
+      lines.forEach(t => {
+        if (y > 280) { doc.addPage(); y = 20; }
         doc.text(t, 10, y);
         y += 7;
-        if (y > 280) { doc.addPage(); y = 10; }
       });
+      y += 4;
     });
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(16);
+    if (y > 280) { doc.addPage(); y = 20; }
+    doc.text('References', 10, y);
+    y += 8;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(12);
+    doc.splitTextToSize(citations || '', 180).forEach(t => {
+      if (y > 280) { doc.addPage(); y = 20; }
+      doc.text(t, 10, y);
+      y += 7;
+    });
+    return doc;
+  };
+
+  const downloadAsPDF = () => {
+    const doc = createPdfDoc();
     doc.save(`${projectTitle.replace(/\s+/g, '_')}_review.pdf`);
   };
 
   const generatePdfBlob = () => {
-    const doc = new jsPDF();
-    const lines = fullText.split('\n');
-    let y = 10;
-    lines.forEach(line => {
-      const parts = doc.splitTextToSize(line, 180);
-      parts.forEach(t => {
-        doc.text(t, 10, y);
-        y += 7;
-        if (y > 280) { doc.addPage(); y = 10; }
-      });
-    });
+    const doc = createPdfDoc();
     return doc.output('blob');
   };
 
@@ -269,9 +288,9 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
               <h3 className="text-lg font-semibold">Download</h3>
               <p className="text-sm text-slate-500 dark:text-primary-400 mt-1">Download the complete review.</p>
               <button onClick={downloadAsPDF} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
-                  Download PDF
+                  Download Report as PDF
               </button>
-              <button onClick={downloadZip} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">Download ZIP with PDFs</button>
+              <button onClick={downloadZip} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">Download ZIP with Full Text PDFs</button>
               <label className="mt-2 flex items-center text-sm">
                 <input type="checkbox" className="mr-2" checked={autoExport} onChange={e => setAutoExport(e.target.checked)} /> Auto-export on finish
               </label>

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { Chart, BarController, BarElement, CategoryScale, LinearScale } from 'chart.js';
 import JSZip from 'jszip';
+import { jsPDF } from 'jspdf';
 import { Paper, CitationStyle, SearchLogEntry, PrismaCounts, ScreeningDecision, DefaultDraftSections } from '../types';
 import { generateCitations } from '../services/geminiService';
 import { calculatePrismaCounts } from '../utils/prismaUtils';
@@ -101,35 +102,57 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
     }
   }, [papers, citationStyle, model]);
   
-  const downloadAsTxt = () => {
-    const blob = new Blob([fullText], { type: 'text/plain;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${projectTitle.replace(/\s+/g, '_')}_review.txt`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+  const downloadAsPDF = () => {
+    const doc = new jsPDF();
+    const lines = fullText.split('\n');
+    let y = 10;
+    lines.forEach(line => {
+      const parts = doc.splitTextToSize(line, 180);
+      parts.forEach(t => {
+        doc.text(t, 10, y);
+        y += 7;
+        if (y > 280) { doc.addPage(); y = 10; }
+      });
+    });
+    doc.save(`${projectTitle.replace(/\s+/g, '_')}_review.pdf`);
   };
 
-  const downloadAsRIS = () => {
-    const lines = papers.filter(p => p.fullTextDecision === ScreeningDecision.KEEP).map(p => `TY  - JOUR\nTI  - ${p.title}\nAU  - ${p.authors.join('; ')}\nPY  - ${p.year}\nUR  - ${p.fullTextUrl}\nER  -`);
-    const blob = new Blob([lines.join('\n')], { type: 'application/x-research-info-systems' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${projectTitle.replace(/\s+/g, '_')}.ris`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+  const generatePdfBlob = () => {
+    const doc = new jsPDF();
+    const lines = fullText.split('\n');
+    let y = 10;
+    lines.forEach(line => {
+      const parts = doc.splitTextToSize(line, 180);
+      parts.forEach(t => {
+        doc.text(t, 10, y);
+        y += 7;
+        if (y > 280) { doc.addPage(); y = 10; }
+      });
+    });
+    return doc.output('blob');
   };
 
   const downloadZip = async () => {
     const zip = new JSZip();
-    zip.file('review.txt', fullText);
-    zip.file('citations.ris', papers.map(p => p.title).join('\n'));
+    zip.file('review.pdf', generatePdfBlob());
+
+    const included = papers.filter(p => p.fullTextDecision === ScreeningDecision.KEEP);
+    for (const p of included) {
+      const url = p.oaPdfUrl || p.fullTextUrl;
+      if (url && url.endsWith('.pdf')) {
+        try {
+          const resp = await fetch(url);
+          if (resp.ok) {
+            const blob = await resp.blob();
+            const safeTitle = p.title.replace(/[^a-z0-9]/gi, '_').slice(0, 30);
+            zip.file(`${safeTitle}.pdf`, blob);
+          }
+        } catch (err) {
+          console.warn('Failed to fetch PDF', err);
+        }
+      }
+    }
+
     const content = await zip.generateAsync({ type: 'blob' });
     const url = URL.createObjectURL(content);
     const a = document.createElement('a');
@@ -160,7 +183,7 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
 
   useEffect(() => {
     if (autoExport && citations) {
-      downloadAsTxt();
+      downloadAsPDF();
       downloadSearchLog();
     }
   }, [autoExport, citations]);
@@ -245,11 +268,10 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
             <div>
               <h3 className="text-lg font-semibold">Download</h3>
               <p className="text-sm text-slate-500 dark:text-primary-400 mt-1">Download the complete review.</p>
-              <button onClick={downloadAsTxt} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
-                  Download .txt
+              <button onClick={downloadAsPDF} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+                  Download PDF
               </button>
-              <button onClick={downloadAsRIS} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">Download .ris</button>
-              <button onClick={downloadZip} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">Download ZIP</button>
+              <button onClick={downloadZip} className="mt-3 w-full inline-flex justify-center items-center px-4 py-2 border border-slate-300 dark:border-primary-700 text-sm font-medium rounded-md shadow-sm text-slate-700 dark:text-primary-200 bg-white dark:bg-primary-800 hover:bg-slate-50 dark:hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">Download ZIP with PDFs</button>
               <label className="mt-2 flex items-center text-sm">
                 <input type="checkbox" className="mr-2" checked={autoExport} onChange={e => setAutoExport(e.target.checked)} /> Auto-export on finish
               </label>

--- a/pages/ExportPage.tsx
+++ b/pages/ExportPage.tsx
@@ -44,6 +44,7 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
   }, [papers, searchLog, duplicateCount]);
 
   const chartRef = useRef<HTMLCanvasElement | null>(null);
+  const chartInstance = useRef<Chart | null>(null);
 
   useEffect(() => {
     if (!chartRef.current) return;
@@ -53,11 +54,16 @@ const ExportPage: React.FC<ExportPageProps> = ({ papers, searchLog, draft, proje
       acc[p.dbSource] = (acc[p.dbSource] || 0) + 1;
       return acc;
     }, {} as Record<string,number>);
-    new Chart(ctx, {
+    chartInstance.current?.destroy();
+    chartInstance.current = new Chart(ctx, {
       type: 'bar',
       data: { labels: Object.keys(data), datasets: [{ label: 'Included', data: Object.values(data), backgroundColor: '#3b82f6' }] },
       options: { responsive: false }
     });
+    return () => {
+      chartInstance.current?.destroy();
+      chartInstance.current = null;
+    };
   }, [papers]);
 
   const sections = useMemo(() => {

--- a/pages/ProjectPage.tsx
+++ b/pages/ProjectPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ProjectDetails, Paper, SearchLogEntry } from '../types';
+import { ProjectDetails, Paper, SearchLogEntry, SearchProfile } from '../types';
 import ProjectPreviewCard from '../components/ProjectPreviewCard';
 import { performSearch } from '../services/searchService';
 import { developSearchStrategy } from '../services/geminiService';
@@ -15,13 +15,28 @@ interface ProjectPageProps {
   onBack: () => void;
   model: string;
   searchLog: SearchLogEntry[];
+  testing: boolean;
 }
 
-const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDetails, setPapers, setSearchLog, setDuplicateCount, onStartSearch, onBack, model, searchLog }) => {
+const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDetails, setPapers, setSearchLog, setDuplicateCount, onStartSearch, onBack, model, searchLog, testing }) => {
   const [isProcessing, setIsProcessing] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
   const [strategyDeveloped, setStrategyDeveloped] = useState(false);
   const [recommendedDatabases, setRecommendedDatabases] = useState<string[]>([]);
+
+  const handleSaveProfile = () => {
+    const newProfile: SearchProfile = {
+      id: Date.now().toString(),
+      name: `Profile ${projectDetails.searchProfiles?.length ?? 0 + 1}`,
+      searchTerms: projectDetails.searchTerms,
+      sourceFilters: {},
+    };
+    setProjectDetails(prev => ({
+      ...prev,
+      searchProfiles: [...(prev.searchProfiles || []), newProfile],
+      activeProfileId: newProfile.id,
+    }));
+  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setProjectDetails(prev => ({ ...prev, [e.target.name]: e.target.value }));
@@ -56,7 +71,7 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
     setIsProcessing(true);
     setLoadingMessage("Performing literature search across recommended databases...");
     try {
-      const { papers, searchLog, duplicateCount } = await performSearch(projectDetails, recommendedDatabases);
+      const { papers, searchLog, duplicateCount } = await performSearch(projectDetails, recommendedDatabases, testing ? 10 : undefined);
       setPapers(papers);
       setSearchLog(searchLog);
       setDuplicateCount(duplicateCount);
@@ -107,7 +122,16 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
           </div>
 
           <div>
-            <label htmlFor="searchTerms" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Boolean Term Suggestions</label>
+            <div className="flex items-center justify-between">
+              <label htmlFor="searchTerms" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Boolean Term Suggestions</label>
+              <button type="button" onClick={handleSaveProfile} className="text-xs text-primary-600">Save as Profile</button>
+            </div>
+            {projectDetails.searchProfiles && projectDetails.searchProfiles.length > 0 && (
+              <select className="mt-1 block w-full border rounded" value={projectDetails.activeProfileId || ''} onChange={e => setProjectDetails(prev => ({ ...prev, activeProfileId: e.target.value }))}>
+                <option value="">Current</option>
+                {projectDetails.searchProfiles.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            )}
             <textarea name="searchTerms" id="searchTerms" rows={4} value={projectDetails.searchTerms} onChange={handleChange} disabled={strategyDeveloped} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 font-mono text-sm disabled:bg-slate-100 dark:disabled:bg-primary-800/50" placeholder='e.g. ("myocardial infarction" OR "heart attack") AND (prevention OR therapy)'></textarea>
             {strategyDeveloped && <p className="mt-1 text-xs text-slate-500 dark:text-primary-400">Query has been finalized by the AI. To change it, you must go back and restart this step.</p>}
           </div>

--- a/pages/ProjectPage.tsx
+++ b/pages/ProjectPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ProjectDetails, Paper, SearchLogEntry, SearchProfile } from '../types';
+import { ProjectDetails, Paper, SearchLogEntry } from '../types';
 import ProjectPreviewCard from '../components/ProjectPreviewCard';
 import { performSearch } from '../services/searchService';
 import { developSearchStrategy } from '../services/geminiService';
@@ -30,27 +30,14 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
     setSelectedDatabases(prev => prev.includes(db) ? prev.filter(d => d !== db) : [...prev, db]);
   };
 
-  const handleSaveProfile = () => {
-    const newProfile: SearchProfile = {
-      id: Date.now().toString(),
-      name: `Profile ${projectDetails.searchProfiles?.length ?? 0 + 1}`,
-      searchTerms: projectDetails.searchTerms,
-      sourceFilters: {},
-    };
-    setProjectDetails(prev => ({
-      ...prev,
-      searchProfiles: [...(prev.searchProfiles || []), newProfile],
-      activeProfileId: newProfile.id,
-    }));
-  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setProjectDetails(prev => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
   const handleDevelopStrategy = async () => {
-    if (!projectDetails.description && !projectDetails.searchTerms) {
-      alert("Please provide a research question/description and some term suggestions to begin.");
+    if (!projectDetails.description) {
+      alert("Please provide a research question and scope to begin.");
       return;
     }
     setIsProcessing(true);
@@ -112,38 +99,29 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
     URL.revokeObjectURL(url);
   };
 
-  const isStrategyFormValid = projectDetails.description || projectDetails.searchTerms;
+  const isStrategyFormValid = !!projectDetails.description;
   const isSearchFormValid = strategyDeveloped && projectDetails.searchTerms && selectedDatabases.length > 0;
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
       <div className="lg:col-span-2 bg-white dark:bg-primary-900 p-8 rounded-lg shadow-lg border border-slate-200 dark:border-primary-700">
         <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Define Your Project</h2>
-        <p className="mt-2 text-sm text-slate-600 dark:text-primary-400">Provide your research question and initial terms. The AI will develop a comprehensive search strategy for you.</p>
+        <p className="mt-2 text-sm text-slate-600 dark:text-primary-400">Describe your research question and scope. The AI will craft boolean terms and suggest databases based on your input.</p>
         
         <div className="mt-6 space-y-6">
           <div>
             <label htmlFor="description" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Research Question and Description</label>
-            <textarea name="description" id="description" rows={4} value={projectDetails.description} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500" placeholder="Outline the objectives and scope of your systematic review..."></textarea>
+            <textarea name="description" id="description" rows={4} value={projectDetails.description} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500" placeholder="e.g. Evaluate treatments for chronic migraine in adults, focusing on randomized trials from the last decade."></textarea>
           </div>
 
           <div>
-            <div className="flex items-center justify-between">
-              <label htmlFor="searchTerms" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Boolean Term Suggestions</label>
-              <button type="button" onClick={handleSaveProfile} className="text-xs text-primary-600">Save as Profile</button>
-            </div>
-            {projectDetails.searchProfiles && projectDetails.searchProfiles.length > 0 && (
-              <select className="mt-1 block w-full border rounded" value={projectDetails.activeProfileId || ''} onChange={e => setProjectDetails(prev => ({ ...prev, activeProfileId: e.target.value }))}>
-                <option value="">Current</option>
-                {projectDetails.searchProfiles.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
-              </select>
-            )}
-            <textarea name="searchTerms" id="searchTerms" rows={4} value={projectDetails.searchTerms} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 font-mono text-sm" placeholder='e.g. ("myocardial infarction" OR "heart attack") AND (prevention OR therapy)'></textarea>
+            <label htmlFor="analysisPlan" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Define the Analysis</label>
+            <textarea name="analysisPlan" id="analysisPlan" rows={3} value={projectDetails.analysisPlan || ''} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" placeholder="Summarize study quality, outcomes, and compare interventions" />
           </div>
 
           <div>
-            <label htmlFor="analysisFocus" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Analysis Focus (optional)</label>
-            <textarea name="analysisFocus" id="analysisFocus" rows={2} value={projectDetails.analysisFocus || ''} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" placeholder="e.g. compare interventions by indication" />
+            <label htmlFor="reportStructure" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Report Structure</label>
+            <textarea name="reportStructure" id="reportStructure" rows={3} value={projectDetails.reportStructure || ''} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" placeholder="Introduction\nMethods\nResults\nDiscussion\nConclusion" />
           </div>
 
           {strategyDeveloped && (

--- a/pages/ProjectPage.tsx
+++ b/pages/ProjectPage.tsx
@@ -22,7 +22,13 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
   const [isProcessing, setIsProcessing] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
   const [strategyDeveloped, setStrategyDeveloped] = useState(false);
-  const [recommendedDatabases, setRecommendedDatabases] = useState<string[]>([]);
+  const [selectedDatabases, setSelectedDatabases] = useState<string[]>([]);
+
+  const allDatabases = ['PubMed','Crossref','OpenAlex','arXiv','SemanticScholar','ERIC','BASE','NASA ADS','DataCite','WHO GIM/LILACS','DBLP'];
+
+  const toggleDatabase = (db: string) => {
+    setSelectedDatabases(prev => prev.includes(db) ? prev.filter(d => d !== db) : [...prev, db]);
+  };
 
   const handleSaveProfile = () => {
     const newProfile: SearchProfile = {
@@ -57,7 +63,7 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
         searchTerms: strategy.finalizedQuery,
         queryVariants: strategy.queryVariants
       }));
-      setRecommendedDatabases(strategy.recommendedDatabases);
+      setSelectedDatabases(strategy.recommendedDatabases);
       setStrategyDeveloped(true);
     } catch (error) {
       console.error("Failed to develop strategy:", error);
@@ -69,9 +75,9 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
 
   const handleStartSearch = async () => {
     setIsProcessing(true);
-    setLoadingMessage("Performing literature search across recommended databases...");
+    setLoadingMessage("Performing literature search across selected databases...");
     try {
-      const { papers, searchLog, duplicateCount } = await performSearch(projectDetails, recommendedDatabases, testing ? 10 : undefined);
+      const { papers, searchLog, duplicateCount } = await performSearch(projectDetails, selectedDatabases, testing ? 10 : undefined);
       setPapers(papers);
       setSearchLog(searchLog);
       setDuplicateCount(duplicateCount);
@@ -107,7 +113,7 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
   };
 
   const isStrategyFormValid = projectDetails.description || projectDetails.searchTerms;
-  const isSearchFormValid = strategyDeveloped && projectDetails.searchTerms && recommendedDatabases.length > 0;
+  const isSearchFormValid = strategyDeveloped && projectDetails.searchTerms && selectedDatabases.length > 0;
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -132,21 +138,21 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
                 {projectDetails.searchProfiles.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
               </select>
             )}
-            <textarea name="searchTerms" id="searchTerms" rows={4} value={projectDetails.searchTerms} onChange={handleChange} disabled={strategyDeveloped} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 font-mono text-sm disabled:bg-slate-100 dark:disabled:bg-primary-800/50" placeholder='e.g. ("myocardial infarction" OR "heart attack") AND (prevention OR therapy)'></textarea>
-            {strategyDeveloped && <p className="mt-1 text-xs text-slate-500 dark:text-primary-400">Query has been finalized by the AI. To change it, you must go back and restart this step.</p>}
+            <textarea name="searchTerms" id="searchTerms" rows={4} value={projectDetails.searchTerms} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 font-mono text-sm" placeholder='e.g. ("myocardial infarction" OR "heart attack") AND (prevention OR therapy)'></textarea>
           </div>
 
           {strategyDeveloped && (
             <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-primary-300">AI Recommended Databases</label>
-              <div className="mt-2 flex gap-4 p-3 bg-slate-50 dark:bg-primary-950 rounded-md border border-slate-200 dark:border-primary-700">
-                  {recommendedDatabases.map(db => (
-                      <span key={db} className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200">
-                          {db}
-                      </span>
-                  ))}
+              <label className="block text-sm font-medium text-slate-700 dark:text-primary-300">Select Databases</label>
+              <div className="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {allDatabases.map(db => (
+                  <label key={db} className="inline-flex items-center">
+                    <input type="checkbox" className="h-4 w-4 text-primary-600 border-gray-300 rounded" checked={selectedDatabases.includes(db)} onChange={() => toggleDatabase(db)} />
+                    <span className="ml-2 text-sm">{db}</span>
+                  </label>
+                ))}
               </div>
-              <p className="mt-1 text-xs text-slate-500 dark:text-primary-400">The literature search will be performed on these databases.</p>
+              <p className="mt-1 text-xs text-slate-500 dark:text-primary-400">Edit the list if you want to add or remove databases.</p>
             </div>
           )}
         </div>

--- a/pages/ProjectPage.tsx
+++ b/pages/ProjectPage.tsx
@@ -141,6 +141,11 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ projectDetails, setProjectDet
             <textarea name="searchTerms" id="searchTerms" rows={4} value={projectDetails.searchTerms} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 font-mono text-sm" placeholder='e.g. ("myocardial infarction" OR "heart attack") AND (prevention OR therapy)'></textarea>
           </div>
 
+          <div>
+            <label htmlFor="analysisFocus" className="block text-sm font-medium text-slate-700 dark:text-primary-300">Analysis Focus (optional)</label>
+            <textarea name="analysisFocus" id="analysisFocus" rows={2} value={projectDetails.analysisFocus || ''} onChange={handleChange} className="mt-1 block w-full rounded-md border-slate-300 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" placeholder="e.g. compare interventions by indication" />
+          </div>
+
           {strategyDeveloped && (
             <div>
               <label className="block text-sm font-medium text-slate-700 dark:text-primary-300">Select Databases</label>

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -79,7 +79,10 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     for (let i = 0; i < papersToClassify.length; i++) {
       if (pauseRef.current) break;
       const paper = papersToClassify[i];
+      console.log('Classifying', stage, paper.id);
       const classification: any = await classifyWithWorker(paper);
+      console.log('Result', stage, paper.id, classification);
+      await new Promise(r => setTimeout(r, 1000));
       
       const paperIndex = updatedPapers.findIndex(p => p.id === paper.id);
       if (paperIndex !== -1) {

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -30,8 +30,12 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
   const pauseRef = useRef(false);
   const workerRef = useRef<Worker>();
 
-  const getDecisionField = (stage: ScreeningStage) => `${stage}Decision` as keyof Paper;
-  const getReasonField = (stage: ScreeningStage) => `${stage}ExclusionReason` as keyof Paper;
+  const mapField = (stage: ScreeningStage, suffix: string) => {
+    if (stage === 'full-text') return `fullText${suffix}` as keyof Paper;
+    return `${stage}${suffix}` as keyof Paper;
+  };
+  const getDecisionField = (stage: ScreeningStage) => mapField(stage, 'Decision');
+  const getReasonField = (stage: ScreeningStage) => mapField(stage, 'ExclusionReason');
 
   const classifyAllPapersForStage = useCallback(async (stage: ScreeningStage) => {
     pauseRef.current = false;
@@ -89,12 +93,12 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
         const decision = classification.decision === 'keep' ? ScreeningDecision.KEEP : ScreeningDecision.EXCLUDE;
         updatedPapers[paperIndex] = {
           ...updatedPapers[paperIndex],
-          [`${stage}Decision`]: decision,
-          [`${stage}Confidence`]: classification.confidence,
-          [`${stage}Justification`]: classification.justification,
+          [getDecisionField(stage)]: decision,
+          [`${stage === 'full-text' ? 'fullText' : stage}Confidence`]: classification.confidence,
+          [`${stage === 'full-text' ? 'fullText' : stage}Justification`]: classification.justification,
           // If AI excludes, we can pre-fill a reason
-          [`${stage}ExclusionReason`]: decision === ScreeningDecision.EXCLUDE ? ExclusionReason.OTHER : undefined,
-        };
+          [getReasonField(stage)]: decision === ScreeningDecision.EXCLUDE ? ExclusionReason.OTHER : undefined,
+        } as Paper;
         // update local array only; apply to state once finished or paused
       }
       setProgress(((i + 1) / papersToClassify.length) * 100);

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { FixedSizeList as List } from 'react-window';
 import { Paper, ScreeningDecision, ProjectDetails, ExclusionReason } from '../types';
 import { classifyPaperPart } from '../services/geminiService';
 import { findOpenAccessPdf } from '../services/unpaywallService';
+import { findOpenAltPdf } from '../services/openAltService';
 import Modal from '../components/Modal';
 
 interface ScreeningPageProps {
@@ -23,11 +25,16 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
   const [progress, setProgress] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPaper, setSelectedPaper] = useState<Paper | null>(null);
+  const [hasStarted, setHasStarted] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const pauseRef = useRef(false);
+  const workerRef = useRef<Worker>();
 
   const getDecisionField = (stage: ScreeningStage) => `${stage}Decision` as keyof Paper;
   const getReasonField = (stage: ScreeningStage) => `${stage}ExclusionReason` as keyof Paper;
 
   const classifyAllPapersForStage = useCallback(async (stage: ScreeningStage) => {
+    pauseRef.current = false;
     setIsLoading(true);
     setProgress(0);
     
@@ -44,11 +51,29 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     }
 
     let updatedPapers = [...papers];
+    if (!workerRef.current) {
+      workerRef.current = new Worker(new URL('../workers/classifyWorker.ts', import.meta.url), { type: 'module' });
+    }
+
+    const worker = workerRef.current;
+
+    const classifyWithWorker = (paper: Paper) => {
+      return new Promise<any>(resolve => {
+        const handler = (e: MessageEvent) => {
+          if (e.data.id === paper.id) {
+            worker.removeEventListener('message', handler);
+            resolve(e.data.result);
+          }
+        };
+        worker.addEventListener('message', handler);
+        worker.postMessage({ stage, paper: { id: paper.id, content: stage === 'title' ? paper.title : (paper.abstract || paper.title) }, project: projectDetails, model });
+      });
+    };
+
     for (let i = 0; i < papersToClassify.length; i++) {
+      if (pauseRef.current) break;
       const paper = papersToClassify[i];
-      const contentToClassify = stage === 'title' ? paper.title : (paper.abstract || paper.title);
-      // NOTE: A real full-text review would fetch content, here we just use the abstract again as a proxy.
-      const classification = await classifyPaperPart(stage, contentToClassify, projectDetails, model);
+      const classification: any = await classifyWithWorker(paper);
       
       const paperIndex = updatedPapers.findIndex(p => p.id === paper.id);
       if (paperIndex !== -1) {
@@ -61,17 +86,17 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
           // If AI excludes, we can pre-fill a reason
           [`${stage}ExclusionReason`]: decision === ScreeningDecision.EXCLUDE ? ExclusionReason.OTHER : undefined,
         };
-        setPapers([...updatedPapers]);
+        // update local array only; apply to state once finished or paused
       }
       setProgress(((i + 1) / papersToClassify.length) * 100);
     }
-    
+    setPapers(updatedPapers);
     setIsLoading(false);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectDetails, model, papers.length]);
 
   useEffect(() => {
-      // Find the first paper that needs classification in the current stage to avoid re-running on every paper update
+      if (!hasStarted || isPaused || isLoading) return;
       const decisionField = getDecisionField(currentStage);
       const requiresClassification = papers.some(p => {
           if (currentStage === 'title') return !p[decisionField];
@@ -81,7 +106,7 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
       if (requiresClassification) {
         classifyAllPapersForStage(currentStage);
       }
-  }, [currentStage, papers, classifyAllPapersForStage]);
+  }, [hasStarted, isPaused, isLoading, currentStage, papers, classifyAllPapersForStage]);
   
   const handleDecisionChange = async (paperId: string, decision: ScreeningDecision) => {
     // Optimistically update the UI
@@ -104,9 +129,15 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     if (currentStage === 'full-text' && decision === ScreeningDecision.KEEP) {
       const paper = updatedPapers.find(p => p.id === paperId);
       if (paper) {
-        const pdfUrl = await findOpenAccessPdf(paper.id);
+        let pdfUrl: string | null = null;
+        if (projectDetails.useUnpaywall) {
+          pdfUrl = await findOpenAccessPdf(paper.id);
+        }
+        if (!pdfUrl && projectDetails.useOpenAlt) {
+          pdfUrl = await findOpenAltPdf(paper.id);
+        }
         if (pdfUrl) {
-            setPapers(prev => prev.map(p => p.id === paperId ? { ...p, oaPdfUrl: pdfUrl } : p));
+          setPapers(prev => prev.map(p => p.id === paperId ? { ...p, oaPdfUrl: pdfUrl } : p));
         }
       }
     }
@@ -131,10 +162,39 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     return true;
   });
 
+  const startScreening = () => {
+    setHasStarted(true);
+    setIsPaused(false);
+  };
+
+  const pauseScreening = () => {
+    pauseRef.current = true;
+    setIsPaused(true);
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (isModalOpen) return;
+      const pending = papersForCurrentStage.find(p => !p[getDecisionField(currentStage)]);
+      if (!pending) return;
+      if (e.key.toLowerCase() === 'k') handleDecisionChange(pending.id, ScreeningDecision.KEEP);
+      if (e.key.toLowerCase() === 'e') handleDecisionChange(pending.id, ScreeningDecision.EXCLUDE);
+      if (e.key === 'Enter') handleNextStage();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [papersForCurrentStage, currentStage, handleDecisionChange, handleNextStage, isModalOpen]);
+
+  const resumeScreening = () => {
+    setIsPaused(false);
+  };
+
   const handleNextStage = () => {
     const currentIndex = STAGES.indexOf(currentStage);
     if (currentIndex < STAGES.length - 1) {
       setCurrentStage(STAGES[currentIndex + 1]);
+      setHasStarted(false);
+      setIsPaused(false);
     } else {
       onComplete();
     }
@@ -168,11 +228,25 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
                     {stage.charAt(0).toUpperCase() + stage.slice(1)} Screening
                 </button>
             ))}
-          </nav>
+      </nav>
         </div>
       </div>
-      
+
        <div className="text-center my-4 text-sm font-medium text-slate-500 dark:text-primary-400">{getStageStats()}</div>
+
+      {!hasStarted ? (
+        <div className="text-center my-4">
+          <button onClick={startScreening} className="px-4 py-2 bg-primary-600 text-white rounded-md">Start Screening</button>
+        </div>
+      ) : (
+        <div className="text-center my-4">
+          {isPaused ? (
+            <button onClick={resumeScreening} className="px-4 py-2 bg-primary-600 text-white rounded-md">Resume</button>
+          ) : (
+            <button onClick={pauseScreening} className="px-4 py-2 bg-primary-600 text-white rounded-md">Pause</button>
+          )}
+        </div>
+      )}
 
       {isLoading && papersForCurrentStage.some(p => !p[getDecisionField(currentStage)]) && (
         <div className="my-4">
@@ -193,59 +267,63 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
             </tr>
           </thead>
           <tbody className="bg-white dark:bg-primary-900 divide-y divide-slate-200 dark:divide-primary-700">
-            {papersForCurrentStage.map(paper => {
-              const decisionField = getDecisionField(currentStage);
-              const reasonField = getReasonField(currentStage);
-              return (
-              <tr key={paper.id}>
-                <td className="px-6 py-4 whitespace-normal max-w-xl align-top">
-                  <div className="font-bold text-slate-900 dark:text-white">{paper.title}</div>
-                  <div className="text-sm text-slate-500 dark:text-primary-400">{paper.authors.join(', ')} ({paper.year})</div>
-                  <div className="text-xs text-slate-400 dark:text-primary-500">Source: {paper.dbSource}</div>
-                  <div className="mt-2 text-sm text-slate-600 dark:text-primary-300">
-                      <button onClick={() => openModal(paper)} className="text-primary-600 dark:text-primary-400 hover:underline">View Details</button>
-                  </div>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap align-top">
-                  {paper[`${currentStage}Confidence` as keyof Paper] !== undefined ? (
-                      <div className="flex flex-col">
-                         <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full self-start ${paper[decisionField] === ScreeningDecision.KEEP ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
-                              {paper[decisionField]} ({paper[`${currentStage}Confidence` as keyof Paper]}%)
-                          </span>
-                          <span className="text-xs text-slate-500 dark:text-primary-500 mt-1 italic max-w-xs block">{paper[`${currentStage}Justification` as keyof Paper] as string}</span>
-                      </div>
-                  ) : (<span className="text-xs text-slate-400 dark:text-primary-500 italic">Pending AI...</span>)}
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap align-top">
-                  <fieldset>
-                    <div className="space-y-2">
-                      <div className="flex items-center">
-                        <input id={`keep-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.KEEP} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.KEEP)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500"/>
-                        <label htmlFor={`keep-${paper.id}-${currentStage}`} className="ml-2 block text-sm font-medium text-slate-700 dark:text-primary-300">Keep</label>
-                      </div>
-                      <div className="flex items-center">
-                        <input id={`exclude-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.EXCLUDE} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.EXCLUDE)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500"/>
-                        <label htmlFor={`exclude-${paper.id}-${currentStage}`} className="ml-2 block text-sm font-medium text-slate-700 dark:text-primary-300">Exclude</label>
-                      </div>
+            <List height={400} itemCount={papersForCurrentStage.length} itemSize={180} width="100%">
+              {({index, style}) => {
+                const paper = papersForCurrentStage[index];
+                const decisionField = getDecisionField(currentStage);
+                const reasonField = getReasonField(currentStage);
+                return (
+                <tr key={paper.id} style={style}>
+                  <td className="px-6 py-4 whitespace-normal max-w-xl align-top">
+                    <div className="font-bold text-slate-900 dark:text-white">{paper.title}</div>
+                    <div className="text-sm text-slate-500 dark:text-primary-400">{paper.authors.join(', ')} ({paper.year})</div>
+                    <div className="text-xs text-slate-400 dark:text-primary-500">Source: {paper.dbSource}</div>
+                    <div className="mt-2 text-sm text-slate-600 dark:text-primary-300">
+                        <button onClick={() => openModal(paper)} className="text-primary-600 dark:text-primary-400 hover:underline">View Details</button>
                     </div>
-                  </fieldset>
-                  {paper[decisionField] === ScreeningDecision.EXCLUDE && (
-                      <div className="mt-2">
-                          <select 
-                            value={paper[reasonField] || ''}
-                            onChange={e => handleReasonChange(paper.id, e.target.value as ExclusionReason)}
-                            className="block w-full text-xs rounded-md border-slate-300 text-slate-900 dark:text-primary-100 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500"
-                          >
-                              <option value="" disabled>Select reason...</option>
-                              {Object.values(ExclusionReason).map(reason => (
-                                  <option key={reason} value={reason}>{reason}</option>
-                              ))}
-                          </select>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap align-top">
+                    {paper[`${currentStage}Confidence` as keyof Paper] !== undefined ? (
+                        <div className="flex flex-col">
+                           <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full self-start ${paper[decisionField] === ScreeningDecision.KEEP ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}> 
+                                {paper[decisionField]} ({paper[`${currentStage}Confidence` as keyof Paper]}%)
+                            </span>
+                            <span className="text-xs text-slate-500 dark:text-primary-500 mt-1 italic max-w-xs block">{paper[`${currentStage}Justification` as keyof Paper] as string}</span>
+                        </div>
+                    ) : (<span className="text-xs text-slate-400 dark:text-primary-500 italic">Pending AI...</span>)}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap align-top">
+                    <fieldset>
+                      <div className="space-y-2">
+                        <div className="flex items-center">
+                          <input id={`keep-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.KEEP} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.KEEP)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500"/>
+                          <label htmlFor={`keep-${paper.id}-${currentStage}`} className="ml-2 block text-sm font-medium text-slate-700 dark:text-primary-300">Keep</label>
+                        </div>
+                        <div className="flex items-center">
+                          <input id={`exclude-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.EXCLUDE} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.EXCLUDE)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500"/>
+                          <label htmlFor={`exclude-${paper.id}-${currentStage}`} className="ml-2 block text-sm font-medium text-slate-700 dark:text-primary-300">Exclude</label>
+                        </div>
                       </div>
-                  )}
-                </td>
-              </tr>
-            )})}
+                    </fieldset>
+                    {paper[decisionField] === ScreeningDecision.EXCLUDE && (
+                        <div className="mt-2">
+                            <select
+                              value={paper[reasonField] || ''}
+                              onChange={e => handleReasonChange(paper.id, e.target.value as ExclusionReason)}
+                              className="block w-full text-xs rounded-md border-slate-300 text-slate-900 dark:text-primary-100 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500"
+                            >
+                                <option value="" disabled>Select reason...</option>
+                                {Object.values(ExclusionReason).map(reason => (
+                                    <option key={reason} value={reason}>{reason}</option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
+                  </td>
+                </tr>
+                );
+              }}
+            </List>
           </tbody>
         </table>
       </div>
@@ -263,7 +341,19 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
         </button>
       </div>
 
-       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} paper={selectedPaper} />
+
+      {papers.some(p => p.duplicateOf) && (
+        <div className="my-8 p-4 border border-dashed border-slate-300 rounded">
+          <h3 className="font-semibold mb-2">Review duplicates</h3>
+          <ul className="list-disc pl-6 text-sm space-y-1">
+            {papers.filter(p => p.duplicateOf).map(p => (
+              <li key={p.id}>{p.title} (duplicate of {p.duplicateOf})</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} paper={selectedPaper} />
 
     </div>
   );

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -263,74 +263,74 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
       )}
 
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-slate-200 dark:divide-primary-700">
-          <thead className="bg-slate-50 dark:bg-primary-950/50">
-            <tr>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-slate-500 dark:text-primary-300 uppercase tracking-wider">Paper Details</th>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-slate-500 dark:text-primary-300 uppercase tracking-wider">AI Suggestion</th>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-slate-500 dark:text-primary-300 uppercase tracking-wider">Your Decision</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white dark:bg-primary-900 divide-y divide-slate-200 dark:divide-primary-700">
-            <List height={400} itemCount={papersForCurrentStage.length} itemSize={180} width="100%">
-              {({index, style}) => {
-                const paper = papersForCurrentStage[index];
-                const decisionField = getDecisionField(currentStage);
-                const reasonField = getReasonField(currentStage);
-                return (
-                <tr key={paper.id} style={style}>
-                  <td className="px-6 py-4 whitespace-normal max-w-xl align-top">
+        <div className="min-w-full divide-y divide-slate-200 dark:divide-primary-700">
+          <div className="hidden md:grid grid-cols-3 bg-slate-50 dark:bg-primary-950/50">
+            <div className="px-6 py-3 text-left text-xs font-medium text-slate-500 dark:text-primary-300 uppercase tracking-wider">Paper Details</div>
+            <div className="px-6 py-3 text-left text-xs font-medium text-slate-500 dark:text-primary-300 uppercase tracking-wider">AI Suggestion</div>
+            <div className="px-6 py-3 text-left text-xs font-medium text-slate-500 dark:text-primary-300 uppercase tracking-wider">Your Decision</div>
+          </div>
+          <List height={400} itemCount={papersForCurrentStage.length} itemSize={180} width="100%">
+            {({ index, style }) => {
+              const paper = papersForCurrentStage[index];
+              const decisionField = getDecisionField(currentStage);
+              const reasonField = getReasonField(currentStage);
+              return (
+                <div key={paper.id} style={style} className="grid grid-cols-3 divide-x divide-slate-200 dark:divide-primary-700 bg-white dark:bg-primary-900">
+                  <div className="px-6 py-4 whitespace-normal max-w-xl">
                     <div className="font-bold text-slate-900 dark:text-white">{paper.title}</div>
                     <div className="text-sm text-slate-500 dark:text-primary-400">{paper.authors.join(', ')} ({paper.year})</div>
                     <div className="text-xs text-slate-400 dark:text-primary-500">Source: {paper.dbSource}</div>
                     <div className="mt-2 text-sm text-slate-600 dark:text-primary-300">
-                        <button onClick={() => openModal(paper)} className="text-primary-600 dark:text-primary-400 hover:underline">View Details</button>
+                      <button onClick={() => openModal(paper)} className="text-primary-600 dark:text-primary-400 hover:underline">View Details</button>
                     </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap align-top">
+                  </div>
+                  <div className="px-6 py-4">
                     {paper[`${currentStage}Confidence` as keyof Paper] !== undefined ? (
-                        <div className="flex flex-col">
-                           <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full self-start ${paper[decisionField] === ScreeningDecision.KEEP ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}> 
-                                {paper[decisionField]} ({paper[`${currentStage}Confidence` as keyof Paper]}%)
-                            </span>
-                            <span className="text-xs text-slate-500 dark:text-primary-500 mt-1 italic max-w-xs block">{paper[`${currentStage}Justification` as keyof Paper] as string}</span>
-                        </div>
-                    ) : (<span className="text-xs text-slate-400 dark:text-primary-500 italic">Pending AI...</span>)}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap align-top">
+                      <div className="flex flex-col">
+                        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full self-start ${paper[decisionField] === ScreeningDecision.KEEP ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>{paper[decisionField]} ({paper[`${currentStage}Confidence` as keyof Paper]}%)</span>
+                        <span className="text-xs text-slate-500 dark:text-primary-500 mt-1 italic max-w-xs block">{paper[`${currentStage}Justification` as keyof Paper] as string}</span>
+                      </div>
+                    ) : (
+                      <span className="text-xs text-slate-400 dark:text-primary-500 italic">Pending AI...</span>
+                    )}
+                  </div>
+                  <div className="px-6 py-4">
                     <fieldset>
                       <div className="space-y-2">
                         <div className="flex items-center">
-                          <input id={`keep-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.KEEP} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.KEEP)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500"/>
+                          <input id={`keep-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.KEEP} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.KEEP)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500" />
                           <label htmlFor={`keep-${paper.id}-${currentStage}`} className="ml-2 block text-sm font-medium text-slate-700 dark:text-primary-300">Keep</label>
                         </div>
                         <div className="flex items-center">
-                          <input id={`exclude-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.EXCLUDE} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.EXCLUDE)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500"/>
+                          <input id={`exclude-${paper.id}-${currentStage}`} name={`decision-${paper.id}-${currentStage}`} type="radio" checked={paper[decisionField] === ScreeningDecision.EXCLUDE} onChange={() => handleDecisionChange(paper.id, ScreeningDecision.EXCLUDE)} className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500" />
                           <label htmlFor={`exclude-${paper.id}-${currentStage}`} className="ml-2 block text-sm font-medium text-slate-700 dark:text-primary-300">Exclude</label>
                         </div>
                       </div>
                     </fieldset>
                     {paper[decisionField] === ScreeningDecision.EXCLUDE && (
-                        <div className="mt-2">
-                            <select
-                              value={paper[reasonField] || ''}
-                              onChange={e => handleReasonChange(paper.id, e.target.value as ExclusionReason)}
-                              className="block w-full text-xs rounded-md border-slate-300 text-slate-900 dark:text-primary-100 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500"
-                            >
-                                <option value="" disabled>Select reason...</option>
-                                {Object.values(ExclusionReason).map(reason => (
-                                    <option key={reason} value={reason}>{reason}</option>
-                                ))}
-                            </select>
-                        </div>
+                      <div className="mt-2">
+                        <select
+                          value={paper[reasonField] || ''}
+                          onChange={(e) => handleReasonChange(paper.id, e.target.value as ExclusionReason)}
+                          className="block w-full text-xs rounded-md border-slate-300 text-slate-900 dark:text-primary-100 dark:bg-primary-800 dark:border-primary-700 shadow-sm focus:ring-primary-500 focus:border-primary-500"
+                        >
+                          <option value="" disabled>
+                            Select reason...
+                          </option>
+                          {Object.values(ExclusionReason).map((reason) => (
+                            <option key={reason} value={reason}>
+                              {reason}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
                     )}
-                  </td>
-                </tr>
-                );
-              }}
-            </List>
-          </tbody>
-        </table>
+                  </div>
+                </div>
+              );
+            }}
+          </List>
+        </div>
       </div>
       
       <div className="mt-8 pt-5 border-t border-slate-200 dark:border-primary-700 flex items-center gap-4">

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -51,23 +51,29 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     }
 
     let updatedPapers = [...papers];
-    if (!workerRef.current) {
-      workerRef.current = new Worker(new URL('../workers/classifyWorker.ts', import.meta.url), { type: 'module' });
+    if (!workerRef.current && import.meta.env.VITE_USE_WORKERS) {
+      try {
+        workerRef.current = new Worker(new URL('../workers/classifyWorker.ts', import.meta.url), { type: 'module' });
+      } catch (err) {
+        console.warn('Worker failed, falling back to main thread', err);
+      }
     }
 
-    const worker = workerRef.current;
-
     const classifyWithWorker = (paper: Paper) => {
-      return new Promise<any>(resolve => {
-        const handler = (e: MessageEvent) => {
-          if (e.data.id === paper.id) {
-            worker.removeEventListener('message', handler);
-            resolve(e.data.result);
-          }
-        };
-        worker.addEventListener('message', handler);
-        worker.postMessage({ stage, paper: { id: paper.id, content: stage === 'title' ? paper.title : (paper.abstract || paper.title) }, project: projectDetails, model });
-      });
+      if (workerRef.current) {
+        const worker = workerRef.current;
+        return new Promise<any>(resolve => {
+          const handler = (e: MessageEvent) => {
+            if (e.data.id === paper.id) {
+              worker.removeEventListener('message', handler);
+              resolve(e.data.result);
+            }
+          };
+          worker.addEventListener('message', handler);
+          worker.postMessage({ stage, paper: { id: paper.id, content: stage === 'title' ? paper.title : (paper.abstract || paper.title) }, project: projectDetails, model });
+        });
+      }
+      return classifyPaperPart(stage, stage === 'title' ? paper.title : (paper.abstract || paper.title), projectDetails, model);
     };
 
     for (let i = 0; i < papersToClassify.length; i++) {
@@ -151,8 +157,7 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     if (currentStage === 'title') return true;
     const prevStage = STAGES[STAGES.indexOf(currentStage) - 1] as ScreeningStage;
     const prevDecision = p[getDecisionField(prevStage)];
-    // Papers move on if they are explicitly kept. Undecided also counts as "not excluded".
-    return prevDecision === ScreeningDecision.KEEP || prevDecision === ScreeningDecision.UNDECIDED || !prevDecision;
+    return prevDecision === ScreeningDecision.KEEP;
   });
 
   const allClassifiedForStage = papersForCurrentStage.every(p => {

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -186,7 +186,7 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     setIsPaused(false);
   };
 
-  const handleNextStage = () => {
+  function handleNextStage() {
     const currentIndex = STAGES.indexOf(currentStage);
     if (currentIndex < STAGES.length - 1) {
       setCurrentStage(STAGES[currentIndex + 1]);
@@ -195,7 +195,7 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     } else {
       onComplete();
     }
-  };
+  }
 
   const openModal = (paper: Paper) => {
     setSelectedPaper(paper);

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -102,17 +102,9 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
   }, [projectDetails, model, papers.length]);
 
   useEffect(() => {
-      if (!hasStarted || isPaused || isLoading) return;
-      const decisionField = getDecisionField(currentStage);
-      const requiresClassification = papers.some(p => {
-          if (currentStage === 'title') return !p[decisionField];
-          const prevStageDecision = p[getDecisionField(STAGES[STAGES.indexOf(currentStage) - 1])];
-          return prevStageDecision === ScreeningDecision.KEEP && !p[decisionField];
-      });
-      if (requiresClassification) {
-        classifyAllPapersForStage(currentStage);
-      }
-  }, [hasStarted, isPaused, isLoading, currentStage, papers, classifyAllPapersForStage]);
+      if (!hasStarted || isPaused) return;
+      classifyAllPapersForStage(currentStage);
+  }, [hasStarted, isPaused, currentStage, classifyAllPapersForStage]);
   
   const handleDecisionChange = async (paperId: string, decision: ScreeningDecision) => {
     // Optimistically update the UI

--- a/pages/ScreeningPage.tsx
+++ b/pages/ScreeningPage.tsx
@@ -102,7 +102,7 @@ const ScreeningPage: React.FC<ScreeningPageProps> = ({ papers, setPapers, projec
     setPapers(updatedPapers);
     setIsLoading(false);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectDetails, model, papers.length]);
+  }, [papers, projectDetails, model]);
 
   useEffect(() => {
       if (!hasStarted || isPaused) return;

--- a/pages/SetupPage.tsx
+++ b/pages/SetupPage.tsx
@@ -3,13 +3,15 @@ import { SparklesIcon } from '../components/Icons';
 
 interface SetupPageProps {
   onComplete: () => void;
+  onResume?: () => void;
+  hasSnapshot?: boolean;
   model: string;
   setModel: (model: string) => void;
   testing: boolean;
   setTesting: (val: boolean) => void;
 }
 
-const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel, testing, setTesting }) => {
+const SetupPage: React.FC<SetupPageProps> = ({ onComplete, onResume, hasSnapshot, model, setModel, testing, setTesting }) => {
   const availableModels = ['gemini-2.5-pro', 'gemini-2.5-flash'];
 
   return (
@@ -54,13 +56,21 @@ const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel, test
           </label>
         </div>
         
-        <div className="pt-4">
+        <div className="pt-4 space-y-2">
             <button
               onClick={onComplete}
               className="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
             >
               Next: Define Project
             </button>
+            {hasSnapshot && onResume && (
+              <button
+                onClick={onResume}
+                className="w-full flex justify-center py-2 px-4 border border-primary-600 rounded-md shadow-sm text-sm font-medium text-primary-700 bg-white hover:bg-slate-50 dark:bg-primary-800 dark:text-primary-200 dark:border-primary-600"
+              >
+                Resume Previous Session
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/pages/SetupPage.tsx
+++ b/pages/SetupPage.tsx
@@ -1,14 +1,35 @@
 import React from 'react';
 import { SparklesIcon } from '../components/Icons';
 
+import { ProjectDetails, SourceSetting } from '../types';
+
 interface SetupPageProps {
   onComplete: () => void;
   model: string;
   setModel: (model: string) => void;
+  testing: boolean;
+  setTesting: (val: boolean) => void;
+  useUnpaywall: boolean;
+  setUseUnpaywall: (val: boolean) => void;
+  useOpenAlt: boolean;
+  setUseOpenAlt: (val: boolean) => void;
+  projectDetails: ProjectDetails;
+  setProjectDetails: React.Dispatch<React.SetStateAction<ProjectDetails>>;
 }
 
-const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel }) => {
+const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel, testing, setTesting, useUnpaywall, setUseUnpaywall, useOpenAlt, setUseOpenAlt, projectDetails, setProjectDetails }) => {
   const availableModels = ['gemini-2.5-pro', 'gemini-2.5-flash'];
+  const dataSources = ['PubMed','Crossref','OpenAlex','arXiv','SemanticScholar','ERIC','BASE','NASA ADS','DataCite','WHO GIM/LILACS','DBLP'];
+
+  const handleSourceToggle = (source: string, field: keyof SourceSetting, value: any) => {
+    setProjectDetails(prev => ({
+      ...prev,
+      sourceFilters: {
+        ...prev.sourceFilters,
+        [source]: { ...prev.sourceFilters?.[source], enabled: prev.sourceFilters?.[source]?.enabled ?? false, [field]: value }
+      }
+    }));
+  };
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -39,8 +60,60 @@ const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel }) =>
                 Select the AI model to power your review.
               </p>
             </div>
+        </div>
+        <div>
+          <label className="inline-flex items-center mt-2">
+            <input
+              type="checkbox"
+              className="h-4 w-4 text-primary-600 border-gray-300 rounded"
+              checked={testing}
+              onChange={e => setTesting(e.target.checked)}
+            />
+            <span className="ml-2 text-sm text-slate-700 dark:text-primary-300" title="Maximum of 10 papers per source after duplicates are removed">Testing mode (limit results to 10)</span>
+          </label>
+        </div>
+        <div className="space-y-2 mt-4">
+          <label className="inline-flex items-center">
+            <input type="checkbox" className="h-4 w-4 text-primary-600 border-gray-300 rounded" checked={useUnpaywall} onChange={e => setUseUnpaywall(e.target.checked)} />
+            <span className="ml-2 text-sm text-slate-700 dark:text-primary-300">Use Unpaywall for PDFs</span>
+          </label>
+          <div className="pl-6 grid grid-cols-3 gap-2">
+            <input type="number" placeholder="From" className="border rounded p-1" />
+            <input type="number" placeholder="To" className="border rounded p-1" />
+            <input type="text" placeholder="Lang" className="border rounded p-1" />
           </div>
-          <div className="pt-4">
+          <label className="inline-flex items-center mt-2">
+            <input type="checkbox" className="h-4 w-4 text-primary-600 border-gray-300 rounded" checked={useOpenAlt} onChange={e => setUseOpenAlt(e.target.checked)} />
+            <span className="ml-2 text-sm text-slate-700 dark:text-primary-300">Use OpenAlt for PDFs</span>
+          </label>
+          <div className="pl-6 grid grid-cols-3 gap-2">
+            <input type="number" placeholder="From" className="border rounded p-1" />
+            <input type="number" placeholder="To" className="border rounded p-1" />
+            <input type="text" placeholder="Lang" className="border rounded p-1" />
+          </div>
+        </div>
+        <div className="mt-6 space-y-4">
+          <h3 className="text-lg font-semibold">Sources</h3>
+          {dataSources.map(src => {
+            const settings = projectDetails.sourceFilters?.[src] || { enabled: false } as SourceSetting;
+            return (
+              <div key={src} className="border p-2 rounded">
+                <label className="inline-flex items-center">
+                  <input type="checkbox" className="h-4 w-4 text-primary-600 border-gray-300 rounded" checked={settings.enabled} onChange={e => handleSourceToggle(src, 'enabled', e.target.checked)} />
+                  <span className="ml-2 text-sm">{src}</span>
+                </label>
+                {settings.enabled && (
+                  <div className="mt-2 grid grid-cols-3 gap-2 pl-4">
+                    <input type="number" placeholder="From" value={settings.yearFrom || ''} onChange={e => handleSourceToggle(src, 'yearFrom', e.target.value ? parseInt(e.target.value) : undefined)} className="border rounded p-1" />
+                    <input type="number" placeholder="To" value={settings.yearTo || ''} onChange={e => handleSourceToggle(src, 'yearTo', e.target.value ? parseInt(e.target.value) : undefined)} className="border rounded p-1" />
+                    <input type="text" placeholder="Lang" value={settings.language || ''} onChange={e => handleSourceToggle(src, 'language', e.target.value)} className="border rounded p-1" />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        <div className="pt-4">
             <button
               onClick={onComplete}
               className="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"

--- a/pages/SetupPage.tsx
+++ b/pages/SetupPage.tsx
@@ -1,35 +1,16 @@
 import React from 'react';
 import { SparklesIcon } from '../components/Icons';
 
-import { ProjectDetails, SourceSetting } from '../types';
-
 interface SetupPageProps {
   onComplete: () => void;
   model: string;
   setModel: (model: string) => void;
   testing: boolean;
   setTesting: (val: boolean) => void;
-  useUnpaywall: boolean;
-  setUseUnpaywall: (val: boolean) => void;
-  useOpenAlt: boolean;
-  setUseOpenAlt: (val: boolean) => void;
-  projectDetails: ProjectDetails;
-  setProjectDetails: React.Dispatch<React.SetStateAction<ProjectDetails>>;
 }
 
-const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel, testing, setTesting, useUnpaywall, setUseUnpaywall, useOpenAlt, setUseOpenAlt, projectDetails, setProjectDetails }) => {
+const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel, testing, setTesting }) => {
   const availableModels = ['gemini-2.5-pro', 'gemini-2.5-flash'];
-  const dataSources = ['PubMed','Crossref','OpenAlex','arXiv','SemanticScholar','ERIC','BASE','NASA ADS','DataCite','WHO GIM/LILACS','DBLP'];
-
-  const handleSourceToggle = (source: string, field: keyof SourceSetting, value: any) => {
-    setProjectDetails(prev => ({
-      ...prev,
-      sourceFilters: {
-        ...prev.sourceFilters,
-        [source]: { ...prev.sourceFilters?.[source], enabled: prev.sourceFilters?.[source]?.enabled ?? false, [field]: value }
-      }
-    }));
-  };
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -72,47 +53,7 @@ const SetupPage: React.FC<SetupPageProps> = ({ onComplete, model, setModel, test
             <span className="ml-2 text-sm text-slate-700 dark:text-primary-300" title="Maximum of 10 papers per source after duplicates are removed">Testing mode (limit results to 10)</span>
           </label>
         </div>
-        <div className="space-y-2 mt-4">
-          <label className="inline-flex items-center">
-            <input type="checkbox" className="h-4 w-4 text-primary-600 border-gray-300 rounded" checked={useUnpaywall} onChange={e => setUseUnpaywall(e.target.checked)} />
-            <span className="ml-2 text-sm text-slate-700 dark:text-primary-300">Use Unpaywall for PDFs</span>
-          </label>
-          <div className="pl-6 grid grid-cols-3 gap-2">
-            <input type="number" placeholder="From" className="border rounded p-1" />
-            <input type="number" placeholder="To" className="border rounded p-1" />
-            <input type="text" placeholder="Lang" className="border rounded p-1" />
-          </div>
-          <label className="inline-flex items-center mt-2">
-            <input type="checkbox" className="h-4 w-4 text-primary-600 border-gray-300 rounded" checked={useOpenAlt} onChange={e => setUseOpenAlt(e.target.checked)} />
-            <span className="ml-2 text-sm text-slate-700 dark:text-primary-300">Use OpenAlt for PDFs</span>
-          </label>
-          <div className="pl-6 grid grid-cols-3 gap-2">
-            <input type="number" placeholder="From" className="border rounded p-1" />
-            <input type="number" placeholder="To" className="border rounded p-1" />
-            <input type="text" placeholder="Lang" className="border rounded p-1" />
-          </div>
-        </div>
-        <div className="mt-6 space-y-4">
-          <h3 className="text-lg font-semibold">Sources</h3>
-          {dataSources.map(src => {
-            const settings = projectDetails.sourceFilters?.[src] || { enabled: false } as SourceSetting;
-            return (
-              <div key={src} className="border p-2 rounded">
-                <label className="inline-flex items-center">
-                  <input type="checkbox" className="h-4 w-4 text-primary-600 border-gray-300 rounded" checked={settings.enabled} onChange={e => handleSourceToggle(src, 'enabled', e.target.checked)} />
-                  <span className="ml-2 text-sm">{src}</span>
-                </label>
-                {settings.enabled && (
-                  <div className="mt-2 grid grid-cols-3 gap-2 pl-4">
-                    <input type="number" placeholder="From" value={settings.yearFrom || ''} onChange={e => handleSourceToggle(src, 'yearFrom', e.target.value ? parseInt(e.target.value) : undefined)} className="border rounded p-1" />
-                    <input type="number" placeholder="To" value={settings.yearTo || ''} onChange={e => handleSourceToggle(src, 'yearTo', e.target.value ? parseInt(e.target.value) : undefined)} className="border rounded p-1" />
-                    <input type="text" placeholder="Lang" value={settings.language || ''} onChange={e => handleSourceToggle(src, 'language', e.target.value)} className="border rounded p-1" />
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
+        
         <div className="pt-4">
             <button
               onClick={onComplete}

--- a/pages/SummaryPage.tsx
+++ b/pages/SummaryPage.tsx
@@ -10,9 +10,10 @@ interface SummaryPageProps {
   onComplete: () => void;
   onBack: () => void;
   model: string;
+  analysisFocus: string;
 }
 
-const SummaryPage: React.FC<SummaryPageProps> = ({ papers, summaries, setSummaries, onComplete, onBack, model }) => {
+const SummaryPage: React.FC<SummaryPageProps> = ({ papers, summaries, setSummaries, onComplete, onBack, model, analysisFocus }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [activeAccordion, setActiveAccordion] = useState<string | null>(null);
@@ -26,7 +27,7 @@ const SummaryPage: React.FC<SummaryPageProps> = ({ papers, summaries, setSummari
     let currentSummaries = [...summaries];
     for(let i=0; i<papersToSummarize.length; i++) {
         const paper = papersToSummarize[i];
-        const summaryData = await generateStructuredSummary(paper, model);
+        const summaryData = await generateStructuredSummary(paper, model, analysisFocus);
         currentSummaries.push({
             paperId: paper.id,
             paperTitle: paper.title,

--- a/pages/SummaryPage.tsx
+++ b/pages/SummaryPage.tsx
@@ -10,10 +10,10 @@ interface SummaryPageProps {
   onComplete: () => void;
   onBack: () => void;
   model: string;
-  analysisFocus: string;
+  analysisPlan: string;
 }
 
-const SummaryPage: React.FC<SummaryPageProps> = ({ papers, summaries, setSummaries, onComplete, onBack, model, analysisFocus }) => {
+const SummaryPage: React.FC<SummaryPageProps> = ({ papers, summaries, setSummaries, onComplete, onBack, model, analysisPlan }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [activeAccordion, setActiveAccordion] = useState<string | null>(null);
@@ -27,7 +27,7 @@ const SummaryPage: React.FC<SummaryPageProps> = ({ papers, summaries, setSummari
     let currentSummaries = [...summaries];
     for(let i=0; i<papersToSummarize.length; i++) {
         const paper = papersToSummarize[i];
-        const summaryData = await generateStructuredSummary(paper, model, analysisFocus);
+        const summaryData = await generateStructuredSummary(paper, model, analysisPlan);
         currentSummaries.push({
             paperId: paper.id,
             paperTitle: paper.title,

--- a/pages/SummaryPage.tsx
+++ b/pages/SummaryPage.tsx
@@ -111,6 +111,10 @@ const SummaryPage: React.FC<SummaryPageProps> = ({ papers, summaries, setSummari
         >
             Back
         </button>
+        <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 text-sm text-primary-600">Re-run Search</button>
         <button onClick={onComplete} disabled={isLoading || summaries.length !== papers.length} className="flex-grow flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:bg-slate-400 disabled:cursor-not-allowed">
           Next: Draft Review
         </button>

--- a/services/databaseConnectors.ts
+++ b/services/databaseConnectors.ts
@@ -1,4 +1,4 @@
-import { Paper } from '../types';
+import { Paper, SearchParams } from '../types';
 
 const APP_EMAIL = "autoreview-user@example.com"; // Polite API usage
 
@@ -122,8 +122,11 @@ const fetchPubMedAbstracts = async (idList: string[]): Promise<Map<string, strin
 };
 
 
-export const searchCrossref = async (query: string): Promise<Paper[]> => {
-    const url = `https://api.crossref.org/works?query.bibliographic=${encodeURIComponent(query)}&rows=50&mailto=${APP_EMAIL}`;
+export const searchCrossref = async (params: SearchParams): Promise<Paper[]> => {
+    const query = params.query;
+    let url = `https://api.crossref.org/works?query.bibliographic=${encodeURIComponent(query)}&rows=${params.limit || 50}&mailto=${APP_EMAIL}`;
+    if (params.yearFrom) url += `&filter=from-pub-date:${params.yearFrom}`;
+    if (params.yearTo) url += `${params.yearFrom ? ',' : '&filter='}until-pub-date:${params.yearTo}`;
     try {
         const response = await fetch(url);
         if (!response.ok) throw new Error(`Crossref API error: ${response.statusText}`);
@@ -136,8 +139,9 @@ export const searchCrossref = async (query: string): Promise<Paper[]> => {
     }
 };
 
-export const searchPubMed = async (query: string): Promise<Paper[]> => {
-    const eSearchUrl = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=${encodeURIComponent(query)}&retmax=50&retmode=json`;
+export const searchPubMed = async (params: SearchParams): Promise<Paper[]> => {
+    const query = params.query;
+    const eSearchUrl = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=${encodeURIComponent(query)}&retmax=${params.limit || 50}&retmode=json`;
     try {
         const searchResponse = await fetch(eSearchUrl);
         if (!searchResponse.ok) throw new Error(`PubMed ESearch API error: ${searchResponse.statusText}`);
@@ -176,8 +180,9 @@ export const searchPubMed = async (query: string): Promise<Paper[]> => {
     }
 };
 
-export const searchOpenAlex = async (query: string): Promise<Paper[]> => {
-    const url = `https://api.openalex.org/works?search=${encodeURIComponent(query)}&per-page=50&mailto=${APP_EMAIL}`;
+export const searchOpenAlex = async (params: SearchParams): Promise<Paper[]> => {
+    const query = params.query;
+    let url = `https://api.openalex.org/works?search=${encodeURIComponent(query)}&per-page=${params.limit || 50}&mailto=${APP_EMAIL}`;
     try {
         const response = await fetch(url);
         if (!response.ok) throw new Error(`OpenAlex API error: ${response.statusText}`);
@@ -188,4 +193,89 @@ export const searchOpenAlex = async (query: string): Promise<Paper[]> => {
         console.error("Failed to fetch from OpenAlex:", error);
         return [];
     }
+};
+
+export const searchArxiv = async (params: SearchParams): Promise<Paper[]> => {
+    const query = params.query;
+    const url = `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(query)}&start=0&max_results=${params.limit || 50}`;
+    try {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`arXiv API error: ${response.statusText}`);
+        const text = await response.text();
+        const entries = text.split('<entry>').slice(1);
+        const papers: Paper[] = entries.map(entry => {
+            const idMatch = entry.match(/<id>(.*?)<\/id>/);
+            const titleMatch = entry.match(/<title>([\s\S]*?)<\/title>/);
+            const summaryMatch = entry.match(/<summary>([\s\S]*?)<\/summary>/);
+            const authorMatches = Array.from(entry.matchAll(/<name>(.*?)<\/name>/g));
+            const authors = authorMatches.map(m => m[1]);
+            const yearMatch = entry.match(/<published>(\d{4})/);
+            if (!titleMatch) return null;
+            return {
+                id: idMatch ? idMatch[1] : `arxiv-${Math.random()}`,
+                title: titleMatch[1].replace(/\n+/g, ' ').trim(),
+                authors,
+                year: yearMatch ? parseInt(yearMatch[1],10) : 0,
+                source: 'arXiv',
+                abstract: summaryMatch ? summaryMatch[1].replace(/\n+/g, ' ').trim() : '',
+                fullTextUrl: idMatch ? idMatch[1] : '',
+                dbSource: 'arXiv',
+                searchDate: new Date().toISOString(),
+            } as Paper;
+        }).filter((p): p is Paper => p !== null);
+        return papers;
+    } catch (error) {
+        console.error('Failed to fetch from arXiv:', error);
+        return [];
+    }
+};
+
+export const searchSemanticScholar = async (params: SearchParams): Promise<Paper[]> => {
+    const query = params.query;
+    const url = `https://api.semanticscholar.org/graph/v1/paper/search?query=${encodeURIComponent(query)}&limit=${params.limit || 50}&fields=title,authors,year,venue,url,abstract`;
+    try {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`SemanticScholar API error: ${response.statusText}`);
+        const data = await response.json();
+        const papers: Paper[] = data.data?.map((item: any) => ({
+            id: item.paperId,
+            title: item.title,
+            authors: item.authors?.map((a: any) => a.name) || [],
+            year: item.year || 0,
+            source: item.venue || 'Semantic Scholar',
+            abstract: item.abstract || '',
+            fullTextUrl: item.url || '',
+            dbSource: 'SemanticScholar',
+            searchDate: new Date().toISOString(),
+        })) || [];
+        return papers;
+    } catch (error) {
+        console.error('Failed to fetch from Semantic Scholar:', error);
+        return [];
+    }
+};
+
+// Additional data sources - basic stubs returning empty results
+export const searchEric = async (_params: SearchParams): Promise<Paper[]> => {
+    return [];
+};
+
+export const searchBASE = async (_params: SearchParams): Promise<Paper[]> => {
+    return [];
+};
+
+export const searchNASAADS = async (_params: SearchParams): Promise<Paper[]> => {
+    return [];
+};
+
+export const searchDataCite = async (_params: SearchParams): Promise<Paper[]> => {
+    return [];
+};
+
+export const searchWHOLILACS = async (_params: SearchParams): Promise<Paper[]> => {
+    return [];
+};
+
+export const searchDBLP = async (_params: SearchParams): Promise<Paper[]> => {
+    return [];
 };

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -49,7 +49,7 @@ const strategySchema = {
         },
         recommendedDatabases: {
             type: Type.ARRAY,
-            items: { type: Type.STRING, enum: ["PubMed", "Crossref", "OpenAlex"] },
+            items: { type: Type.STRING, enum: ["PubMed", "Crossref", "OpenAlex", "arXiv", "SemanticScholar", "ERIC", "BASE", "NASA ADS", "DataCite", "WHO GIM/LILACS", "DBLP"] },
             description: "A list of recommended databases from the available options based on topic relevance."
         }
     },
@@ -94,7 +94,7 @@ export const developSearchStrategy = async (
     const prompt = `
         Act as an expert systematic review researcher. Your task is to develop a comprehensive search strategy based on the user's input.
         
-        Available databases for searching are: "PubMed", "Crossref", "OpenAlex".
+        Available databases for searching are: "PubMed", "Crossref", "OpenAlex", "arXiv", "SemanticScholar", "ERIC", "BASE", "NASA ADS", "DataCite", "WHO GIM/LILACS", "DBLP".
 
         User's input:
         - Research Question/Description: "${description}"
@@ -123,7 +123,7 @@ export const developSearchStrategy = async (
             suggestedTitle: "Error: Could not generate title",
             finalizedQuery: termSuggestions,
             queryVariants: [],
-            recommendedDatabases: ["PubMed", "Crossref", "OpenAlex"]
+            recommendedDatabases: ["PubMed", "Crossref", "OpenAlex", "arXiv", "SemanticScholar", "ERIC", "BASE", "NASA ADS", "DataCite", "WHO GIM/LILACS", "DBLP"]
         };
     }
 };

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -21,6 +21,11 @@ const logGemini = (entry: GeminiLogEntry) => {
     }
 };
 
+const estimateTokens = (text: string) => {
+    if (!text) return 0;
+    return Math.ceil(text.trim().split(/\s+/).length);
+};
+
 const classificationSchema = {
     type: Type.OBJECT,
     properties: {
@@ -92,11 +97,13 @@ export const classifyPaperPart = async (part: 'title' | 'abstract' | 'full-text'
         });
         const jsonText = response.text.trim();
         const result = JSON.parse(jsonText);
-        logGemini({ timestamp: new Date().toISOString(), action: 'classify', stage: part, ms: performance.now() - start });
+        const tokens = estimateTokens(prompt) + estimateTokens(jsonText);
+        logGemini({ timestamp: new Date().toISOString(), action: 'classify', stage: part, ms: performance.now() - start, tokens });
         return result;
     } catch (error: any) {
         console.error(`Error classifying paper ${part}:`, error);
-        logGemini({ timestamp: new Date().toISOString(), action: 'classify', stage: part, ms: performance.now() - start, error: error?.message || String(error) });
+        const tokens = estimateTokens(prompt);
+        logGemini({ timestamp: new Date().toISOString(), action: 'classify', stage: part, ms: performance.now() - start, error: error?.message || String(error), tokens });
         return { decision: 'exclude', confidence: 0, justification: 'Error during analysis.' };
     }
 };
@@ -132,7 +139,8 @@ export const developSearchStrategy = async (
             }
         });
         const jsonText = response.text.trim();
-        logGemini({ timestamp: new Date().toISOString(), action: 'strategy', ms: performance.now() - start });
+        const tokens = estimateTokens(prompt) + estimateTokens(jsonText);
+        logGemini({ timestamp: new Date().toISOString(), action: 'strategy', ms: performance.now() - start, tokens });
         return JSON.parse(jsonText);
     } catch (error: any) {
         console.error("Error developing search strategy:", error);
@@ -147,12 +155,13 @@ export const developSearchStrategy = async (
 };
 
 
-export const generateStructuredSummary = async (paper: Paper, modelName: string): Promise<Omit<Summary, 'paperId' | 'paperTitle'>> => {
+export const generateStructuredSummary = async (paper: Paper, modelName: string, focus?: string): Promise<Omit<Summary, 'paperId' | 'paperTitle'>> => {
     const prompt = `
         Generate a structured summary of the following paper's abstract. If abstract is empty, use the title.
         Title: "${paper.title}"
         Abstract: "${paper.abstract}"
         Focus on these four areas: Methodology, Key Findings, Research Context, and Conclusions.
+        ${focus ? `Pay particular attention to ${focus}.` : ''}
     `;
     const start = performance.now();
     try {
@@ -165,29 +174,31 @@ export const generateStructuredSummary = async (paper: Paper, modelName: string)
             }
         });
         const jsonText = response.text.trim();
-        logGemini({ timestamp: new Date().toISOString(), action: 'summary', paperId: paper.id, ms: performance.now() - start });
+        const tokens = estimateTokens(prompt) + estimateTokens(jsonText);
+        logGemini({ timestamp: new Date().toISOString(), action: 'summary', paperId: paper.id, ms: performance.now() - start, tokens });
         return JSON.parse(jsonText);
     } catch (error: any) {
         console.error("Error generating structured summary:", error);
-        logGemini({ timestamp: new Date().toISOString(), action: 'summary', paperId: paper.id, ms: performance.now() - start, error: error?.message || String(error) });
+        const tokens = estimateTokens(prompt);
+        logGemini({ timestamp: new Date().toISOString(), action: 'summary', paperId: paper.id, ms: performance.now() - start, error: error?.message || String(error), tokens });
         return { methodology: 'Error', keyFindings: 'Error', researchContext: 'Error', conclusions: 'Error' };
     }
 };
 
-export const generateDraftSection = async (section: DraftSection, content: string | Summary[], modelName: string): Promise<string> => {
+export const generateDraftSection = async (section: DraftSection, content: string | Summary[], modelName: string, focus?: string): Promise<string> => {
     let prompt;
     switch(section) {
         case DraftSection.INTRODUCTION:
             prompt = `Write a compelling introduction for a systematic review titled "${content}". Lay out the research context and state the primary objectives.`;
             break;
         case DraftSection.METHODS:
-            prompt = `Based on the following summaries, write a 'Methods' section for a systematic review. Describe the search strategy, inclusion/exclusion criteria, and data extraction process. The summaries are:\n\n${JSON.stringify(content)}`;
+            prompt = `Based on the following summaries, write a 'Methods' section for a systematic review. Describe the search strategy, inclusion/exclusion criteria, and data extraction process. ${focus ? `Give special consideration to ${focus}.` : ''} The summaries are:\n\n${JSON.stringify(content)}`;
             break;
         case DraftSection.RESULTS:
-            prompt = `Synthesize the 'Key Findings' from the following paper summaries into a coherent 'Results' section. Group findings thematically if possible.\n\n${JSON.stringify(content)}`;
+            prompt = `Synthesize the 'Key Findings' from the following paper summaries into a coherent 'Results' section. Group findings thematically if possible. ${focus ? `Highlight aspects related to ${focus}.` : ''}\n\n${JSON.stringify(content)}`;
             break;
         case DraftSection.DISCUSSION:
-            prompt = `Write a 'Discussion' section based on the following summaries. Interpret the results, discuss implications, mention limitations, and suggest future research directions.\n\n${JSON.stringify(content)}`;
+            prompt = `Write a 'Discussion' section based on the following summaries. Interpret the results, discuss implications, mention limitations, and suggest future research directions. ${focus ? `Discuss how the findings relate to ${focus}.` : ''}\n\n${JSON.stringify(content)}`;
             break;
         case DraftSection.ABSTRACT:
              prompt = `Write a structured abstract (Background, Methods, Results, Conclusion) for a systematic review. The main content is as follows:\n\n${content}`;
@@ -200,11 +211,13 @@ export const generateDraftSection = async (section: DraftSection, content: strin
             model: modelName,
             contents: prompt,
         });
-        logGemini({ timestamp: new Date().toISOString(), action: 'draft', stage: section, ms: performance.now() - start });
+        const tokens = estimateTokens(prompt) + estimateTokens(response.text);
+        logGemini({ timestamp: new Date().toISOString(), action: 'draft', stage: section, ms: performance.now() - start, tokens });
         return response.text;
     } catch (error: any) {
         console.error(`Error generating draft for ${section}:`, error);
-        logGemini({ timestamp: new Date().toISOString(), action: 'draft', stage: section, ms: performance.now() - start, error: error?.message || String(error) });
+        const tokens = estimateTokens(prompt);
+        logGemini({ timestamp: new Date().toISOString(), action: 'draft', stage: section, ms: performance.now() - start, error: error?.message || String(error), tokens });
         return `Error generating content for ${section}.`;
     }
 };
@@ -224,11 +237,13 @@ export const generateCitations = async (papers: Paper[], style: CitationStyle, m
             model: modelName,
             contents: prompt,
         });
-        logGemini({ timestamp: new Date().toISOString(), action: 'citations', ms: performance.now() - start });
+        const tokens = estimateTokens(prompt) + estimateTokens(response.text);
+        logGemini({ timestamp: new Date().toISOString(), action: 'citations', ms: performance.now() - start, tokens });
         return response.text;
     } catch (error: any) {
         console.error(`Error generating citations for style ${style}:`, error);
-        logGemini({ timestamp: new Date().toISOString(), action: 'citations', ms: performance.now() - start, error: error?.message || String(error) });
+        const tokens = estimateTokens(prompt);
+        logGemini({ timestamp: new Date().toISOString(), action: 'citations', ms: performance.now() - start, error: error?.message || String(error), tokens });
         return `Error generating citations.`;
     }
 }

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -16,6 +16,7 @@ const logGemini = (entry: GeminiLogEntry) => {
         const logs: GeminiLogEntry[] = JSON.parse(localStorage.getItem(LOG_KEY) || '[]');
         logs.push(entry);
         localStorage.setItem(LOG_KEY, JSON.stringify(logs));
+        window.dispatchEvent(new Event('geminiLog'));
     } catch (err) {
         console.warn('Failed to write Gemini log', err);
     }
@@ -187,22 +188,24 @@ export const generateStructuredSummary = async (paper: Paper, modelName: string,
 
 export const generateDraftSection = async (section: DraftSection, content: string | Summary[], modelName: string, focus?: string): Promise<string> => {
     let prompt;
-    switch(section) {
-        case DraftSection.INTRODUCTION:
+    switch(section.toLowerCase()) {
+        case 'introduction':
             prompt = `Write a compelling introduction for a systematic review titled "${content}". Lay out the research context and state the primary objectives.`;
             break;
-        case DraftSection.METHODS:
+        case 'methods':
             prompt = `Based on the following summaries, write a 'Methods' section for a systematic review. Describe the search strategy, inclusion/exclusion criteria, and data extraction process. ${focus ? `Give special consideration to ${focus}.` : ''} The summaries are:\n\n${JSON.stringify(content)}`;
             break;
-        case DraftSection.RESULTS:
+        case 'results':
             prompt = `Synthesize the 'Key Findings' from the following paper summaries into a coherent 'Results' section. Group findings thematically if possible. ${focus ? `Highlight aspects related to ${focus}.` : ''}\n\n${JSON.stringify(content)}`;
             break;
-        case DraftSection.DISCUSSION:
+        case 'discussion':
             prompt = `Write a 'Discussion' section based on the following summaries. Interpret the results, discuss implications, mention limitations, and suggest future research directions. ${focus ? `Discuss how the findings relate to ${focus}.` : ''}\n\n${JSON.stringify(content)}`;
             break;
-        case DraftSection.ABSTRACT:
+        case 'abstract':
              prompt = `Write a structured abstract (Background, Methods, Results, Conclusion) for a systematic review. The main content is as follows:\n\n${content}`;
              break;
+        default:
+             prompt = `Write the section titled '${section}' for a systematic review using the following content:\n\n${typeof content === 'string' ? content : JSON.stringify(content)}`;
     }
 
     try {

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,5 +1,5 @@
 import { GoogleGenAI, Type } from "@google/genai";
-import { ProjectDetails, Paper, Summary, DraftSection, CitationStyle, ExclusionReason } from '../types';
+import { ProjectDetails, Paper, Summary, DraftSection, CitationStyle, ExclusionReason, GeminiLogEntry } from '../types';
 
 if (!process.env.API_KEY) {
   // In a real app, you'd want to handle this more gracefully.
@@ -9,6 +9,17 @@ if (!process.env.API_KEY) {
 }
 
 const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+
+const LOG_KEY = 'gemini_logs';
+const logGemini = (entry: GeminiLogEntry) => {
+    try {
+        const logs: GeminiLogEntry[] = JSON.parse(localStorage.getItem(LOG_KEY) || '[]');
+        logs.push(entry);
+        localStorage.setItem(LOG_KEY, JSON.stringify(logs));
+    } catch (err) {
+        console.warn('Failed to write Gemini log', err);
+    }
+};
 
 const classificationSchema = {
     type: Type.OBJECT,
@@ -69,6 +80,7 @@ export const classifyPaperPart = async (part: 'title' | 'abstract' | 'full-text'
         Should this paper be included or excluded? Provide a confidence score and a brief justification.
     `;
 
+    const start = performance.now();
     try {
         const response = await ai.models.generateContent({
             model: modelName,
@@ -79,9 +91,12 @@ export const classifyPaperPart = async (part: 'title' | 'abstract' | 'full-text'
             }
         });
         const jsonText = response.text.trim();
-        return JSON.parse(jsonText);
-    } catch (error) {
+        const result = JSON.parse(jsonText);
+        logGemini({ timestamp: new Date().toISOString(), action: 'classify', stage: part, ms: performance.now() - start });
+        return result;
+    } catch (error: any) {
         console.error(`Error classifying paper ${part}:`, error);
+        logGemini({ timestamp: new Date().toISOString(), action: 'classify', stage: part, ms: performance.now() - start, error: error?.message || String(error) });
         return { decision: 'exclude', confidence: 0, justification: 'Error during analysis.' };
     }
 };
@@ -106,6 +121,7 @@ export const developSearchStrategy = async (
         3.  Refine and expand the user's initial boolean terms. Incorporate relevant synonyms and controlled vocabulary (like MeSH for biomedical topics) to create a single, robust, and finalized boolean query string. This query should be optimized for searching academic databases.
         4.  List the key synonyms or variants you identified.
     `;
+    const start = performance.now();
     try {
         const response = await ai.models.generateContent({
             model: modelName,
@@ -116,9 +132,11 @@ export const developSearchStrategy = async (
             }
         });
         const jsonText = response.text.trim();
+        logGemini({ timestamp: new Date().toISOString(), action: 'strategy', ms: performance.now() - start });
         return JSON.parse(jsonText);
-    } catch (error) {
+    } catch (error: any) {
         console.error("Error developing search strategy:", error);
+        logGemini({ timestamp: new Date().toISOString(), action: 'strategy', ms: performance.now() - start, error: error?.message || String(error) });
         return {
             suggestedTitle: "Error: Could not generate title",
             finalizedQuery: termSuggestions,
@@ -136,6 +154,7 @@ export const generateStructuredSummary = async (paper: Paper, modelName: string)
         Abstract: "${paper.abstract}"
         Focus on these four areas: Methodology, Key Findings, Research Context, and Conclusions.
     `;
+    const start = performance.now();
     try {
         const response = await ai.models.generateContent({
             model: modelName,
@@ -146,9 +165,11 @@ export const generateStructuredSummary = async (paper: Paper, modelName: string)
             }
         });
         const jsonText = response.text.trim();
+        logGemini({ timestamp: new Date().toISOString(), action: 'summary', paperId: paper.id, ms: performance.now() - start });
         return JSON.parse(jsonText);
-    } catch (error) {
+    } catch (error: any) {
         console.error("Error generating structured summary:", error);
+        logGemini({ timestamp: new Date().toISOString(), action: 'summary', paperId: paper.id, ms: performance.now() - start, error: error?.message || String(error) });
         return { methodology: 'Error', keyFindings: 'Error', researchContext: 'Error', conclusions: 'Error' };
     }
 };
@@ -172,15 +193,18 @@ export const generateDraftSection = async (section: DraftSection, content: strin
              prompt = `Write a structured abstract (Background, Methods, Results, Conclusion) for a systematic review. The main content is as follows:\n\n${content}`;
              break;
     }
-    
+
     try {
+        const start = performance.now();
         const response = await ai.models.generateContent({
             model: modelName,
             contents: prompt,
         });
+        logGemini({ timestamp: new Date().toISOString(), action: 'draft', stage: section, ms: performance.now() - start });
         return response.text;
-    } catch (error) {
+    } catch (error: any) {
         console.error(`Error generating draft for ${section}:`, error);
+        logGemini({ timestamp: new Date().toISOString(), action: 'draft', stage: section, ms: performance.now() - start, error: error?.message || String(error) });
         return `Error generating content for ${section}.`;
     }
 };
@@ -194,14 +218,17 @@ export const generateCitations = async (papers: Paper[], style: CitationStyle, m
         ${JSON.stringify(paperData, null, 2)}
     `;
 
+    const start = performance.now();
     try {
         const response = await ai.models.generateContent({
             model: modelName,
             contents: prompt,
         });
+        logGemini({ timestamp: new Date().toISOString(), action: 'citations', ms: performance.now() - start });
         return response.text;
-    } catch (error) {
+    } catch (error: any) {
         console.error(`Error generating citations for style ${style}:`, error);
+        logGemini({ timestamp: new Date().toISOString(), action: 'citations', ms: performance.now() - start, error: error?.message || String(error) });
         return `Error generating citations.`;
     }
 }

--- a/services/openAltService.ts
+++ b/services/openAltService.ts
@@ -1,0 +1,13 @@
+export const findOpenAltPdf = async (doi: string): Promise<string | null> => {
+    if (!doi) return null;
+    const url = `https://api.openalt.org/v1/lookup?doi=${encodeURIComponent(doi)}`;
+    try {
+        const resp = await fetch(url);
+        if (!resp.ok) return null;
+        const data = await resp.json();
+        return data?.pdf_url || null;
+    } catch (err) {
+        console.error('OpenAlt fetch error', err);
+        return null;
+    }
+};

--- a/services/searchService.ts
+++ b/services/searchService.ts
@@ -1,12 +1,12 @@
 import { ProjectDetails, Paper, SearchLogEntry } from '../types';
-import { searchCrossref, searchPubMed, searchOpenAlex } from './databaseConnectors';
+import { searchCrossref, searchPubMed, searchOpenAlex, searchArxiv, searchSemanticScholar, searchEric, searchBASE, searchNASAADS, searchDataCite, searchWHOLILACS, searchDBLP } from './databaseConnectors';
 
-const deduplicatePapers = (papers: Paper[]): { uniquePapers: Paper[], duplicateCount: number } => {
+const deduplicatePapers = (papers: Paper[]): { papers: Paper[], duplicateCount: number } => {
     const doiMap = new Map<string, string>();
     const titleMap = new Map<string, string>();
     let duplicateCount = 0;
 
-    const uniquePapers = [];
+    const result: Paper[] = [];
 
     for (const paper of papers) {
         const cleanDoi = paper.id?.toLowerCase().trim();
@@ -15,42 +15,74 @@ const deduplicatePapers = (papers: Paper[]): { uniquePapers: Paper[], duplicateC
         if (cleanDoi && doiMap.has(cleanDoi)) {
             paper.duplicateOf = doiMap.get(cleanDoi);
             duplicateCount++;
-            continue;
-        }
-        if (cleanTitle && titleMap.has(cleanTitle)) {
+        } else if (cleanTitle && titleMap.has(cleanTitle)) {
             paper.duplicateOf = titleMap.get(cleanTitle);
             duplicateCount++;
-            continue;
+        } else {
+            if (cleanDoi) doiMap.set(cleanDoi, paper.id);
+            if (cleanTitle) titleMap.set(cleanTitle, paper.id);
         }
-
-        if (cleanDoi) {
-            doiMap.set(cleanDoi, paper.id);
-        }
-        if (cleanTitle) {
-            titleMap.set(cleanTitle, paper.id);
-        }
-        uniquePapers.push(paper);
+        result.push(paper);
     }
-    
-    // In this implementation, we return only unique papers and the count of duplicates found.
-    // The original list with flagged duplicates is discarded to simplify downstream processing.
-    return { uniquePapers, duplicateCount };
+
+    return { papers: result, duplicateCount };
 };
 
 
-export const performSearch = async (projectDetails: ProjectDetails, selectedDatabases: string[]) => {
+export const performSearch = async (projectDetails: ProjectDetails, selectedDatabases: string[], limit?: number) => {
     const searchLog: SearchLogEntry[] = [];
     const now = new Date().toISOString();
 
-    const searchPromises = [];
+    const searchPromises = [] as Promise<Paper[]>[];
+
+    const getCached = async (db: string, fn: () => Promise<Paper[]>) => {
+        const filterKey = JSON.stringify(projectDetails.sourceFilters?.[db] || {});
+        const key = `cache_${db}_${projectDetails.searchTerms}_${filterKey}`;
+        const cached = localStorage.getItem(key);
+        if (cached) return JSON.parse(cached) as Paper[];
+        const start = performance.now();
+        const data = await fn();
+        const end = performance.now();
+        localStorage.setItem(key, JSON.stringify(data));
+        const tkey = `timing_${db}`;
+        const timings = JSON.parse(localStorage.getItem(tkey) || '[]');
+        timings.push(end - start);
+        localStorage.setItem(tkey, JSON.stringify(timings));
+        return data;
+    };
+
     if (selectedDatabases.includes('PubMed')) {
-        searchPromises.push(searchPubMed(projectDetails.searchTerms));
+        searchPromises.push(getCached('PubMed', () => searchPubMed({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['PubMed'] || {}) })));
     }
     if (selectedDatabases.includes('Crossref')) {
-        searchPromises.push(searchCrossref(projectDetails.searchTerms));
+        searchPromises.push(getCached('Crossref', () => searchCrossref({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['Crossref'] || {}) })));
     }
     if (selectedDatabases.includes('OpenAlex')) {
-        searchPromises.push(searchOpenAlex(projectDetails.searchTerms));
+        searchPromises.push(getCached('OpenAlex', () => searchOpenAlex({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['OpenAlex'] || {}) })));
+    }
+    if (selectedDatabases.includes('arXiv')) {
+        searchPromises.push(getCached('arXiv', () => searchArxiv({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['arXiv'] || {}) })));
+    }
+    if (selectedDatabases.includes('SemanticScholar')) {
+        searchPromises.push(getCached('SemanticScholar', () => searchSemanticScholar({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['SemanticScholar'] || {}) })));
+    }
+    if (selectedDatabases.includes('ERIC')) {
+        searchPromises.push(getCached('ERIC', () => searchEric({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['ERIC'] || {}) })));
+    }
+    if (selectedDatabases.includes('BASE')) {
+        searchPromises.push(getCached('BASE', () => searchBASE({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['BASE'] || {}) })));
+    }
+    if (selectedDatabases.includes('NASA ADS')) {
+        searchPromises.push(getCached('NASA ADS', () => searchNASAADS({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['NASA ADS'] || {}) })));
+    }
+    if (selectedDatabases.includes('DataCite')) {
+        searchPromises.push(getCached('DataCite', () => searchDataCite({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['DataCite'] || {}) })));
+    }
+    if (selectedDatabases.includes('WHO GIM/LILACS')) {
+        searchPromises.push(getCached('WHO GIM/LILACS', () => searchWHOLILACS({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['WHO GIM/LILACS'] || {}) })));
+    }
+    if (selectedDatabases.includes('DBLP')) {
+        searchPromises.push(getCached('DBLP', () => searchDBLP({ query: projectDetails.searchTerms, limit, ...(projectDetails.sourceFilters?.['DBLP'] || {}) })));
     }
 
 
@@ -72,10 +104,11 @@ export const performSearch = async (projectDetails: ProjectDetails, selectedData
         }
     });
 
-    const { uniquePapers, duplicateCount } = deduplicatePapers(allPapers);
+    const { papers: deduped, duplicateCount } = deduplicatePapers(allPapers);
+    const limitedPapers = limit ? deduped.slice(0, limit) : deduped;
 
     return {
-        papers: uniquePapers,
+        papers: limitedPapers,
         searchLog,
         duplicateCount,
         initialCount: allPapers.length

--- a/services/searchService.ts
+++ b/services/searchService.ts
@@ -43,11 +43,15 @@ export const performSearch = async (projectDetails: ProjectDetails, selectedData
         const start = performance.now();
         const data = await fn();
         const end = performance.now();
-        localStorage.setItem(key, JSON.stringify(data));
-        const tkey = `timing_${db}`;
-        const timings = JSON.parse(localStorage.getItem(tkey) || '[]');
-        timings.push(end - start);
-        localStorage.setItem(tkey, JSON.stringify(timings));
+        try {
+            localStorage.setItem(key, JSON.stringify(data));
+            const tkey = `timing_${db}`;
+            const timings = JSON.parse(localStorage.getItem(tkey) || '[]');
+            timings.push(end - start);
+            localStorage.setItem(tkey, JSON.stringify(timings));
+        } catch (err) {
+            console.warn('Cache write failed', err);
+        }
         return data;
     };
 

--- a/types.ts
+++ b/types.ts
@@ -29,7 +29,8 @@ export interface ProjectDetails {
   description: string;
   searchTerms: string;
   queryVariants: string[];
-  analysisFocus?: string;
+  analysisPlan?: string;
+  reportStructure?: string;
   useUnpaywall?: boolean;
   useOpenAlt?: boolean;
   searchProfiles?: SearchProfile[];

--- a/types.ts
+++ b/types.ts
@@ -29,6 +29,7 @@ export interface ProjectDetails {
   description: string;
   searchTerms: string;
   queryVariants: string[];
+  analysisFocus?: string;
   useUnpaywall?: boolean;
   useOpenAlt?: boolean;
   searchProfiles?: SearchProfile[];
@@ -130,6 +131,7 @@ export interface GeminiLogEntry {
     paperId?: string;
     ms?: number;
     error?: string;
+    tokens?: number;
 }
 
 export interface PrismaCounts {

--- a/types.ts
+++ b/types.ts
@@ -123,6 +123,15 @@ export interface SearchLogEntry {
     date: string; // ISO String
 }
 
+export interface GeminiLogEntry {
+    timestamp: string;
+    action: string;
+    stage?: string;
+    paperId?: string;
+    ms?: number;
+    error?: string;
+}
+
 export interface PrismaCounts {
     identification: Array<{ db: string; hits: number }>;
     duplicates: number;

--- a/types.ts
+++ b/types.ts
@@ -29,6 +29,36 @@ export interface ProjectDetails {
   description: string;
   searchTerms: string;
   queryVariants: string[];
+  useUnpaywall?: boolean;
+  useOpenAlt?: boolean;
+  searchProfiles?: SearchProfile[];
+  activeProfileId?: string;
+  sourceFilters?: Record<string, SourceSetting>;
+}
+
+export interface SourceSetting {
+  enabled: boolean;
+  yearFrom?: number;
+  yearTo?: number;
+  language?: string;
+  docType?: string;
+}
+
+export interface SearchParams {
+  query: string;
+  limit?: number;
+  yearFrom?: number;
+  yearTo?: number;
+  language?: string;
+  docType?: string;
+  cursor?: string;
+}
+
+export interface SearchProfile {
+  id: string;
+  name: string;
+  searchTerms: string;
+  sourceFilters: Record<string, SourceSetting>;
 }
 
 export interface Paper {

--- a/types.ts
+++ b/types.ts
@@ -104,13 +104,15 @@ export interface Summary {
   conclusions: string;
 }
 
-export enum DraftSection {
-  INTRODUCTION = "Introduction",
-  METHODS = "Methods",
-  RESULTS = "Results",
-  DISCUSSION = "Discussion",
-  ABSTRACT = "Abstract",
-}
+export const DefaultDraftSections = [
+  'Introduction',
+  'Methods',
+  'Results',
+  'Discussion',
+  'Abstract',
+] as const;
+
+export type DraftSection = typeof DefaultDraftSections[number] | string;
 
 export enum CitationStyle {
     APA = "APA",

--- a/utils/prismaUtils.ts
+++ b/utils/prismaUtils.ts
@@ -6,7 +6,14 @@ export const calculatePrismaCounts = (
     duplicateCount: number
 ): PrismaCounts => {
     
-    const identification = searchLog.map(log => ({ db: log.database, hits: log.hits }));
+    let identification = searchLog.map(log => ({ db: log.database, hits: log.hits }));
+    if (identification.length === 0) {
+        const dbMap = papers.reduce((acc: Record<string, number>, p) => {
+            if (p.dbSource) acc[p.dbSource] = (acc[p.dbSource] || 0) + 1;
+            return acc;
+        }, {});
+        identification = Object.keys(dbMap).map(db => ({ db, hits: dbMap[db] }));
+    }
     
     const recordsScreened = papers.length;
 

--- a/workers/classifyWorker.ts
+++ b/workers/classifyWorker.ts
@@ -1,0 +1,7 @@
+import { classifyPaperPart } from '../services/geminiService';
+
+self.onmessage = async (e) => {
+  const { stage, paper, project, model } = e.data;
+  const result = await classifyPaperPart(stage, paper.content, project, model);
+  self.postMessage({ id: paper.id, result });
+};


### PR DESCRIPTION
## Summary
- implement new free data source stubs and per-source filters
- add tooltip explaining testing mode
- virtualize screening table with react-window and add keyboard shortcuts
- allow inline edit of paper metadata via modal dialog
- auto-save snapshot every 60s to recover after crash
- draw PRISMA diagram and source bar chart with Chart.js
- support RIS and ZIP exports

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883c642c19083249669482ecd77f2e9